### PR TITLE
Fix typo in error message

### DIFF
--- a/src/rpn_resolver.rs
+++ b/src/rpn_resolver.rs
@@ -9,7 +9,7 @@ use num::{BigInt, One, Zero};
 
 static MALFORMED_ERR: &str = "Runtime Error: The mathematical expression is malformed.";
 static DIVISION_ZERO_ERR: &str = "Runtime error: Divide by zero.";
-static NO_VARIABLE_ERR: &str = "Runtime error: No variable has been defined for assignent.";
+static NO_VARIABLE_ERR: &str = "Runtime error: No variable has been defined for assignment.";
 
 /// The main [`RpnResolver`] contains the core logic of Yarer
 /// for parsing and evaluating a math expression.


### PR DESCRIPTION
## Summary
- fix misspelled "assignent" in `NO_VARIABLE_ERR`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68435e3ae5fc83268d51fdd9ae4763cc