### PR TITLE
Fix documentation reference in Session

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -4,7 +4,7 @@ use num_bigint::BigInt;
 use crate::{rpn_resolver::RpnResolver, token::Number};
 
 /// A [`Session`] is an object that holds a variable heap in the form of a [`HashMap`]
-/// that is borrowed to all the [`RpnResolver`] that are built from the builder [`build_resolver_for`()]
+/// that is borrowed to all the [`RpnResolver`] instances built using [`process()`]
 ///
 /// Example
 ///


### PR DESCRIPTION
## Summary
- update reference to use `process()` in `src/session.rs`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68435edce49883269794b75a78ab66be