### PR TITLE
Fix factorial input checks

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -127,3 +127,13 @@ fn test_session_set() {
     let mut resolver: RpnResolver = session.process("x+2*3/(4-5)");
     assert_eq!(resolver.resolve().unwrap(), Number::DecimalNumber(-2.0));
 }
+
+#[test]
+fn test_factorial_invalid_operand() {
+    let session = Session::init();
+    let mut resolver = session.process("(-1)!");
+    assert!(resolver.resolve().is_err());
+
+    let mut resolver = session.process("2.5!");
+    assert!(resolver.resolve().is_err());
+}


### PR DESCRIPTION
## Summary
- validate factorial operands before calling helper
- compute factorial only for non-negative integers
- update factorial helper to use `BigUint`
- add tests for invalid factorial inputs

## Testing
- `cargo test --quiet`
- `cargo fmt -- --check` *(fails: 'cargo-fmt' is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68435e6d99708326b3328ade66375eec