### PR TITLE
Update CLI help header

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -13,7 +13,15 @@ static VERSION: &str = env!("CARGO_PKG_VERSION");
 static HISTORY_FILE: &str = ".yarer_history";
 
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)] // Read from `Cargo.toml`
+#[command(
+    author,
+    version,
+    about = "Yarer (Yet Another Rust Expression Resolver) ...",
+    long_about = "Yarer (Yet Another Rust Expression Resolver) ...\n\
+                  Copyright (c) 2024 Davassi <gianluigi.davassi@gmail.com>\n\
+                  License MIT OR Apache-2.0",
+    help_template = "{before-help}{name} {version}\n{author-with-newline}{about-with-newline}{usage-heading} {usage}\n\n{all-args}{after-help}"
+)]
 struct Cli {
     #[arg(short, long)]
     quiet: bool,


### PR DESCRIPTION
## Summary
- show version, author, and license in CLI help header using a custom help template

## Testing
- `cargo build`
- `target/debug/yarer --help | head -n 8`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68440bd5f57883269418957b91283b00