### PR TITLE
Fix function argument parsing

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -11,7 +11,7 @@ use regex::Regex;
 pub struct Parser;
 
 static EXPRESSION_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"(\d+\.?\d*|\.\d+|[-+*/^()=×÷!]|[a-zA-Z_][a-zA-Z0-9_]*|)")
+    Regex::new(r"(\d+\.?\d*|\.\d+|[-+*/^(),=×÷!]|[a-zA-Z_][a-zA-Z0-9_]*|)")
         .expect("Should compile regex")
 });
 
@@ -58,6 +58,9 @@ impl Parser {
                             _ => (),
                         }
                     }
+                    expect_operand_next = true;
+                }
+                Token::Comma => {
                     expect_operand_next = true;
                 }
                 _ => (),

--- a/src/rpn_resolver.rs
+++ b/src/rpn_resolver.rs
@@ -231,6 +231,15 @@ impl RpnResolver<'_> {
                     }
                 }
 
+                Token::Comma => {
+                    while let Some(token) = operators_stack.last() {
+                        if matches!(token, Token::Bracket(token::Bracket::Open)) {
+                            break;
+                        }
+                        postfix_stack.push_back(operators_stack.pop().expect("It should not happen."));
+                    }
+                }
+
                 Token::Operator(_op) => {
                     let op1: Token<'_> = t.clone();
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -84,6 +84,8 @@ pub enum Token<'a> {
     Bracket(Bracket),
     /// sin cos tan ln log...
     Function(MathFunction),
+    /// comma separator for function arguments
+    Comma,
     /// a b c x y ...
     Variable(&'a str),
 }
@@ -187,6 +189,7 @@ impl Token<'_> {
                     return Some(Token::from_operator(c).unwrap())
                 }
                 b @ ('(' | ')' | '[' | ']') => return Some(Token::from_bracket(b).unwrap()),
+                ',' => return Some(Token::Comma),
                 _ => (), // continue the flow
             },
             None => return None,
@@ -421,6 +424,7 @@ impl Display for Token<'_> {
             Token::Bracket(v) => write!(f, "({v})"),
             Token::Function(v) => write!(f, "({v})"),
             Token::Variable(v) => write!(f, "({v})"),
+            Token::Comma => write!(f, "(,)")
         }
     }
 }


### PR DESCRIPTION
## Summary
- handle `,` in expression parser
- tokenize comma as `Token::Comma`
- treat commas in the shunting-yard algorithm

## Testing
- `cargo test --quiet`
- `echo -e "max(2^3,3^2)\nquit" | cargo run --quiet --bin yarer --`

------
https://chatgpt.com/codex/tasks/task_e_684411ba85308326a2030d798813c5ed