### PR TITLE
Add floor, ceil, round and exp functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ There are many examples of processed expressions in the [integration test file](
     Sqrt
     Max
     Min
+    Floor
+    Ceil
+    Round
+    Exp
 ```
 
 ## Built-in Defined Constants

--- a/src/rpn_resolver.rs
+++ b/src/rpn_resolver.rs
@@ -197,6 +197,10 @@ impl RpnResolver<'_> {
                             f64::min(value.into(), value2.into())
                         }
                         MathFunction::Sqrt => f64::sqrt(value.into()),
+                        MathFunction::Floor => f64::floor(value.into()),
+                        MathFunction::Ceil => f64::ceil(value.into()),
+                        MathFunction::Round => f64::round(value.into()),
+                        MathFunction::Exp => f64::exp(value.into()),
                         MathFunction::None => return Err(anyhow!("This should never happen!")),
                     };
                     result_stack.push_back(Number::DecimalNumber(res));

--- a/src/token.rs
+++ b/src/token.rs
@@ -118,6 +118,14 @@ pub enum MathFunction {
     Max,
     /// Min value
     Min,
+    /// Rounds down
+    Floor,
+    /// Rounds up
+    Ceil,
+    /// Rounds to nearest integer
+    Round,
+    /// e^x exponentiation
+    Exp,
     /// No function expected
     None,
 }
@@ -168,6 +176,10 @@ impl Token<'_> {
             "sqrt" => Some(MathFunction::Sqrt),
             "max" => Some(MathFunction::Max),
             "min" => Some(MathFunction::Min),
+            "floor" => Some(MathFunction::Floor),
+            "ceil" => Some(MathFunction::Ceil),
+            "round" => Some(MathFunction::Round),
+            "exp" => Some(MathFunction::Exp),
             &_ => None,
         }
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -142,6 +142,12 @@ fn test_expressions() {
     resolve_decimal!("sqrt(2)*sqrt(8)", 4.000000000000001);
     resolve_decimal!("ln(e^(ln(e)))", 1.0);
 
+    resolve_decimal!("floor(3.7)", 3.0);
+    resolve_decimal!("ceil(3.2)", 4.0);
+    resolve_decimal!("round(3.6)", 4.0);
+    resolve_decimal!("round(3.4)", 3.0);
+    resolve_decimal!("exp(1)", std::f64::consts::E);
+
     resolve_err!("min()");
     resolve_err!("max()");
 


### PR DESCRIPTION
## Summary
- add new math functions: `floor`, `ceil`, `round` and `exp`
- implement these operations in the resolver
- expose the new functions in the tokenizer and documentation
- test the new functions

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6847195017108326a3b9b10249653ebc