### PR TITLE
Support semicolon statement chaining

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -11,7 +11,7 @@ use regex::Regex;
 pub struct Parser;
 
 static EXPRESSION_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"(\d+\.?\d*|\.\d+|[-+*/^(),=×÷!]|[a-zA-Z_][a-zA-Z0-9_]*|)")
+    Regex::new(r"(\d+\.?\d*|\.\d+|[-+*/^(),=×÷!;]|[a-zA-Z_][a-zA-Z0-9_]*|)")
         .expect("Should compile regex")
 });
 
@@ -60,7 +60,7 @@ impl Parser {
                     }
                     expect_operand_next = true;
                 }
-                Token::Comma => {
+                Token::Comma | Token::SemiColon => {
                     expect_operand_next = true;
                 }
                 _ => (),

--- a/src/rpn_resolver.rs
+++ b/src/rpn_resolver.rs
@@ -206,6 +206,10 @@ impl RpnResolver<'_> {
                     result_stack.push_back(Number::DecimalNumber(res));
                     var_stack.push_back(None);
                 }
+                Token::SemiColon => {
+                    result_stack.clear();
+                    var_stack.clear();
+                }
                 _ => {
                     return Err(anyhow!(
                         "{} Internal Error at line: {}.",
@@ -269,6 +273,13 @@ impl RpnResolver<'_> {
                         }
                         postfix_stack.push_back(operators_stack.pop().expect("It should not happen."));
                     }
+                }
+
+                Token::SemiColon => {
+                    while let Some(token) = operators_stack.pop() {
+                        postfix_stack.push_back(token);
+                    }
+                    postfix_stack.push_back(Token::SemiColon);
                 }
 
                 Token::Operator(_op) => {

--- a/src/token.rs
+++ b/src/token.rs
@@ -88,6 +88,8 @@ pub enum Token<'a> {
     Comma,
     /// a b c x y ...
     Variable(&'a str),
+    /// Semicolon ';' separator for chained expressions
+    SemiColon,
 }
 
 /// The [`MathFunction`] enum. It represents a common math function.
@@ -202,6 +204,7 @@ impl Token<'_> {
                 }
                 b @ ('(' | ')' | '[' | ']') => return Some(Token::from_bracket(b).unwrap()),
                 ',' => return Some(Token::Comma),
+                ';' => return Some(Token::SemiColon),
                 _ => (), // continue the flow
             },
             None => return None,
@@ -436,7 +439,8 @@ impl Display for Token<'_> {
             Token::Bracket(v) => write!(f, "({v})"),
             Token::Function(v) => write!(f, "({v})"),
             Token::Variable(v) => write!(f, "({v})"),
-            Token::Comma => write!(f, "(,)")
+            Token::Comma => write!(f, "(,)") ,
+            Token::SemiColon => write!(f, "(;)")
         }
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -207,3 +207,17 @@ fn test_factorial_invalid_operand() {
     let mut resolver = session.process("2.5!");
     assert!(resolver.resolve().is_err());
 }
+
+#[test]
+fn test_chained_expressions() {
+    let session = Session::init();
+    let mut resolver = session.process("x=2; y=3; x*y");
+    assert_eq!(resolver.resolve().unwrap(), Number::NaturalNumber(BigInt::from(6)));
+}
+
+#[test]
+fn test_chained_without_assignment() {
+    let session = Session::init();
+    let mut resolver = session.process("1+2; 3+4");
+    assert_eq!(resolver.resolve().unwrap(), Number::NaturalNumber(BigInt::from(7)));
+}


### PR DESCRIPTION
## Summary
- support semicolon tokens in the parser
- parse semicolons in the tokenizer
- flush operator stack and expression state at semicolon
- add evaluation logic for statement separators
- test multi-statement expressions

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68471deca06c832693524980f59b0d29