### PR TITLE
Add normal distribution function

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ There are many examples of processed expressions in the [integration test file](
     Ceil
     Round
     Exp
+    Pdf
     Cdf
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,7 @@
 //! Ceil
 //! Round
 //! Exp
+//! Pdf
 //! Cdf
 //! ```
 /// Parser

--- a/src/rpn_resolver.rs
+++ b/src/rpn_resolver.rs
@@ -2,7 +2,7 @@ use crate::{
     parser::Parser,
     token::{self, MathFunction, Number, Operator, Token},
 };
-use statrs::distribution::{ContinuousCDF, Normal};
+use statrs::distribution::{Continuous, ContinuousCDF, Normal};
 use anyhow::anyhow;
 use log::debug;
 use std::{
@@ -201,6 +201,10 @@ impl RpnResolver<'_> {
                         MathFunction::Floor => f64::floor(value.into()),
                         MathFunction::Ceil => f64::ceil(value.into()),
                         MathFunction::Round => f64::round(value.into()),
+                        MathFunction::Pdf => {
+                            let normal = Normal::new(0.0, 1.0).expect("valid normal dist");
+                            normal.pdf(value.into())
+                        }
                         MathFunction::Cdf => {
                             let normal = Normal::new(0.0, 1.0).expect("valid normal dist");
                             normal.cdf(value.into())

--- a/src/token.rs
+++ b/src/token.rs
@@ -128,6 +128,8 @@ pub enum MathFunction {
     Round,
     /// e^x exponentiation
     Exp,
+    /// Standard Normal probability density function
+    Pdf,
     /// Standard Normal cumulative distribution function
     Cdf,
     /// No function expected
@@ -184,6 +186,7 @@ impl Token<'_> {
             "ceil" => Some(MathFunction::Ceil),
             "round" => Some(MathFunction::Round),
             "exp" => Some(MathFunction::Exp),
+            "pdf" => Some(MathFunction::Pdf),
             "cdf" => Some(MathFunction::Cdf),
             &_ => None,
         }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -148,6 +148,10 @@ fn test_expressions() {
     resolve_decimal!("round(3.4)", 3.0);
     resolve_decimal!("exp(1)", std::f64::consts::E);
     resolve_decimal!("cdf(0)", 0.5);
+    resolve_decimal!(
+        "pdf(0)",
+        0.39894228040143265
+    );
 
     resolve_err!("min()");
     resolve_err!("max()");


### PR DESCRIPTION
## Summary
- add `Pdf` to the list of builtin math functions
- implement `pdf` evaluation in `RpnResolver`
- document new function in README and lib docs
- test `pdf(0)` in integration tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6848a3587f788326830649018bbca831