### PR TITLE
Release 0.2.0: fallible numeric conversions and chained-expression fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yarer"
-version = "0.1.8"
+version = "0.2.0"
 description = "Yarer (Yet Another Rust Expression Resolver) is a library for resolving mathematical expressions. Internally it uses the shunting yard algorithm."
 repository = "https://github.com/davassi/yarer"
 homepage = "https://github.com/davassi/yarer"

--- a/README.md
+++ b/README.md
@@ -52,14 +52,16 @@ and of course, the expression can be re-evaluated if the variable changes.
 
 ## Casting
 
-The result can be cast into an i32 or an f64 (if decimal) using
+The result can be converted into an i32 or an f64 (if decimal) using the
+fallible `TryFrom`/`TryInto` conversions, which return an error instead of
+panicking when the value does not fit the target type:
 
 ```rust
       let result: Number = resolver.resolve().unwrap();
 
-      let int : i32 = result.into();
+      let int : i32 = result.clone().try_into().unwrap();
       // or
-      let float : f64 = result.into();
+      let float : f64 = result.try_into().unwrap();
 ```
 
 ## CLI
@@ -68,7 +70,7 @@ Yarer can also be used from the command line and behaves similarly to GNU bc
 
 ```rust
       $ yarer
-      Yarer v.0.1.8 - Yet Another Rust Expression Resolver.
+      Yarer v.0.2.0 - Yet Another Rust Expression Resolver.
       License MIT OR Apache-2.0
       > (1+9)*(8+2)+0!
       101
@@ -93,6 +95,24 @@ Yarer can also be used from the command line and behaves similarly to GNU bc
 ```
 ## News and Updates
 
+### Version 0.2.0
+
+Yarer 0.2.0 is a correctness-focused release that includes a breaking API change.
+
+**Breaking change:** conversions from `Number` to `i32`, `i64`, `i128` and `f64` are now
+fallible. They are exposed via `TryFrom`/`TryInto` (returning a `ConversionError`) instead of
+the previous panicking `From`/`Into`. Conversion to `BigInt` remains infallible via `From`.
+Update `let n: i32 = result.into();` to `let n: i32 = result.try_into()?;` (or `.unwrap()`).
+
+Other changes:
+
+* Out-of-range numeric conversions now return an error instead of panicking.
+* `Number` → `BigInt` conversion is exact (truncates the rational toward zero) rather than round-tripping through `f64`, so precision is no longer silently lost.
+* A trailing `;` now returns the last segment's value instead of reporting a spurious "malformed expression" error after the assignment already took effect.
+* Malformed segments inside a `;`-chained expression are now rejected instead of being silently discarded.
+* Stricter parser validation: malformed expressions and unexpected tokens raise a clear error.
+* Removed an unused, internally-panicking `BitXor` implementation for `Number`.
+
 ### Version 0.1.8
 
 Yarer 0.1.8 comes with several enhancements:
@@ -107,7 +127,7 @@ Starting with Yarer version 0.1.7, natural numbers are implemented internally us
 
 ```rust
     $ yarer
-      Yarer v.0.1.8 - Yet Another Rust Expression Resolver.
+      Yarer v.0.2.0 - Yet Another Rust Expression Resolver.
       License MIT OR Apache-2.0
       > 78!
       1132428117820629783145752115873204622873174957948825.....
@@ -174,7 +194,7 @@ Using Yarer, the Black–Scholes formula for a European call option can be evalu
 
 ```rust
       $ yarer
-      Yarer v.0.1.8 - Yet Another Rust Expression Resolver.
+      Yarer v.0.2.0 - Yet Another Rust Expression Resolver.
       License MIT OR Apache-2.0
       > S=100;K=100;T=1;r=0.05;sigma=0.2;
       > d1=(ln(S/K)+(r+sigma^2/2)*T)/(sigma*sqrt(T))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,9 +54,9 @@
 //!
 //! let result: Number = resolver.resolve().unwrap();
 //!
-//! let int : i32 = result.clone().into();
+//! let int : i32 = result.clone().try_into().unwrap();
 //! // or
-//! let float : f64 = result.into();
+//! let float : f64 = result.try_into().unwrap();
 //! ```
 //!
 //! Yarer can be used also from command line, and behaves in a very similar manner to GNU bc

--- a/src/rpn_resolver.rs
+++ b/src/rpn_resolver.rs
@@ -79,6 +79,7 @@ impl RpnResolver<'_> {
 
         let mut result_stack: VecDeque<Number> = VecDeque::new();
         let mut var_stack: VecDeque<Option<String>> = VecDeque::new();
+        let mut last_result: Option<Number> = None;
 
         for t in &self.rpn_expr {
             match t {
@@ -297,6 +298,15 @@ impl RpnResolver<'_> {
                     var_stack.push_back(None);
                 }
                 Token::SemiColon => {
+                    // A chained segment just ended. A well-formed segment leaves exactly
+                    // one value on the stack; capture it as the running result, then reset
+                    // for the next segment. An empty segment (e.g. a leading ';') is a no-op.
+                    if !result_stack.is_empty() {
+                        if result_stack.len() != 1 {
+                            return Err(anyhow!(MALFORMED_ERR));
+                        }
+                        last_result = result_stack.pop_back();
+                    }
                     result_stack.clear();
                     var_stack.clear();
                 }
@@ -308,6 +318,12 @@ impl RpnResolver<'_> {
                     ))
                 }
             }
+        }
+
+        // A trailing ';' leaves the working stack empty: fall back to the last
+        // completed segment's value rather than reporting a spurious error.
+        if result_stack.is_empty() {
+            return last_result.ok_or_else(|| anyhow!(MALFORMED_ERR));
         }
 
         if result_stack.len() != 1 || var_stack.len() != 1 {

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,10 +1,9 @@
-use log::debug;
 use num_bigint::BigInt;
 use num_rational::BigRational;
-use num_traits::{FromPrimitive, One, ToPrimitive, Zero};
+use num_traits::{One, ToPrimitive, Zero};
 use std::{
     fmt::Display,
-    ops::{Add, BitXor, Div, Mul, Sub},
+    ops::{Add, Div, Mul, Sub},
 };
 
 /// Enum Type [Number]. Either an BigInt integer [`Number::NaturalNumber`]
@@ -354,24 +353,6 @@ impl Div for Number {
     }
 }
 
-impl BitXor for Number {
-    type Output = Number;
-
-    fn bitxor(self, rhs: Self) -> Self::Output {
-        debug!("{} {}", self, rhs);
-        apply_functional_token_operation(
-            self,
-            rhs,
-            |a, b| BigInt::pow(&a, b.try_into().unwrap()),
-            |a, b| {
-                let af = a.to_f64().expect("Should not happen");
-                let bf = b.to_f64().expect("Should not happen");
-                BigRational::from_float(f64::powf(af, bf)).expect("Should not happen")
-            },
-        )
-    }
-}
-
 /// PartialOrd between [Number]s with the required conversions.
 ///
 impl PartialOrd for Number {
@@ -389,63 +370,90 @@ impl PartialOrd for Number {
     }
 }
 
-impl From<Number> for f64 {
-    fn from(n: Number) -> f64 {
-        match n {
-            Number::NaturalNumber(v) => ToPrimitive::to_f64(&v).expect("Should not happen"),
-            Number::DecimalNumber(v) => v.to_f64().expect("Should not happen"),
-        }
-    }
+/// Error returned when a [`Number`] cannot be converted into a fixed-size
+/// numeric type because the value falls outside that type's representable range.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ConversionError {
+    /// The value does not fit in the requested target type.
+    #[error("value '{value}' is out of range for target type {target}")]
+    OutOfRange {
+        /// The offending value, rendered as a decimal string.
+        value: String,
+        /// The name of the target type that could not hold the value.
+        target: &'static str,
+    },
 }
 
-#[allow(clippy::cast_possible_truncation)]
+/// Converts a [`Number`] into a [`BigInt`], truncating any fractional part
+/// toward zero. This is exact and infallible: a [`BigInt`] holds any integer.
 impl From<Number> for BigInt {
     fn from(n: Number) -> BigInt {
         match n {
             Number::NaturalNumber(v) => v,
-            Number::DecimalNumber(v) => {
-                BigInt::from_f64(v.to_f64().expect("Should not happen")).expect("Should not happen")
-            }
+            // `to_integer` truncates the exact rational toward zero — no lossy f64 round-trip.
+            Number::DecimalNumber(v) => v.to_integer(),
         }
     }
 }
 
-impl From<Number> for i32 {
-    fn from(n: Number) -> i32 {
-        match n {
-            Number::NaturalNumber(v) => ToPrimitive::to_i32(&v).expect("Should not happen"),
-            Number::DecimalNumber(v) => ToPrimitive::to_i32(
-                &BigInt::from_f64(v.to_f64().expect("Should not happen"))
-                    .expect("Should not happen"),
-            )
-            .expect("Should not happen"),
-        }
+/// Fallible conversion to [`f64`]. Fails when the value cannot be represented
+/// as a finite double (e.g. it exceeds [`f64::MAX`]).
+impl TryFrom<Number> for f64 {
+    type Error = ConversionError;
+
+    fn try_from(n: Number) -> Result<Self, Self::Error> {
+        let value = match &n {
+            Number::NaturalNumber(v) => v.to_f64(),
+            Number::DecimalNumber(v) => v.to_f64(),
+        };
+        value
+            .filter(|f| f.is_finite())
+            .ok_or_else(|| ConversionError::OutOfRange {
+                value: n.to_string(),
+                target: "f64",
+            })
     }
 }
 
-impl From<Number> for i64 {
-    fn from(n: Number) -> i64 {
-        match n {
-            Number::NaturalNumber(v) => ToPrimitive::to_i64(&v).expect("Should not happen"),
-            Number::DecimalNumber(v) => ToPrimitive::to_i64(
-                &BigInt::from_f64(v.to_f64().expect("Should not happen"))
-                    .expect("Should not happen"),
-            )
-            .expect("Should not happen"),
-        }
+/// Fallible conversion to [`i32`]: the fractional part is truncated toward zero,
+/// then the integer must fit in the target type.
+impl TryFrom<Number> for i32 {
+    type Error = ConversionError;
+
+    fn try_from(n: Number) -> Result<Self, Self::Error> {
+        let value: BigInt = n.into();
+        value.to_i32().ok_or_else(|| ConversionError::OutOfRange {
+            value: value.to_string(),
+            target: "i32",
+        })
     }
 }
 
-impl From<Number> for i128 {
-    fn from(n: Number) -> i128 {
-        match n {
-            Number::NaturalNumber(v) => ToPrimitive::to_i128(&v).expect("Should not happen"),
-            Number::DecimalNumber(v) => ToPrimitive::to_i128(
-                &BigInt::from_f64(v.to_f64().expect("Should not happen"))
-                    .expect("Should not happen"),
-            )
-            .expect("Should not happen"),
-        }
+/// Fallible conversion to [`i64`]: the fractional part is truncated toward zero,
+/// then the integer must fit in the target type.
+impl TryFrom<Number> for i64 {
+    type Error = ConversionError;
+
+    fn try_from(n: Number) -> Result<Self, Self::Error> {
+        let value: BigInt = n.into();
+        value.to_i64().ok_or_else(|| ConversionError::OutOfRange {
+            value: value.to_string(),
+            target: "i64",
+        })
+    }
+}
+
+/// Fallible conversion to [`i128`]: the fractional part is truncated toward zero,
+/// then the integer must fit in the target type.
+impl TryFrom<Number> for i128 {
+    type Error = ConversionError;
+
+    fn try_from(n: Number) -> Result<Self, Self::Error> {
+        let value: BigInt = n.into();
+        value.to_i128().ok_or_else(|| ConversionError::OutOfRange {
+            value: value.to_string(),
+            target: "i128",
+        })
     }
 }
 
@@ -617,6 +625,46 @@ mod tests {
     }
 
     #[test]
+    fn test_tryfrom_i32_out_of_range_is_err_not_panic() {
+        // 2^100 is a valid NaturalNumber that does not fit in i32:
+        // the conversion must return Err, never panic.
+        let big = Number::NaturalNumber(BigInt::from(2).pow(100));
+        assert!(i32::try_from(big).is_err());
+    }
+
+    #[test]
+    fn test_tryfrom_i64_in_range_ok() {
+        let n = Number::NaturalNumber(BigInt::from(3_265_920));
+        assert_eq!(i64::try_from(n).unwrap(), 3_265_920_i64);
+    }
+
+    #[test]
+    fn test_decimal_to_bigint_is_exact_for_large_values() {
+        // f64 cannot represent 10^30 + 1 exactly, so a round-trip through f64
+        // would lose the +1. Exact conversion via to_integer() must preserve it.
+        let big = BigInt::from(10).pow(30) + BigInt::from(1);
+        let n = Number::DecimalNumber(BigRational::from_integer(big.clone()));
+        assert_eq!(BigInt::from(n), big);
+    }
+
+    #[test]
+    fn test_decimal_to_bigint_truncates_toward_zero() {
+        let pos = Number::DecimalNumber(BigRational::new(BigInt::from(7), BigInt::from(2)));
+        assert_eq!(BigInt::from(pos), BigInt::from(3));
+        let neg = Number::DecimalNumber(BigRational::new(BigInt::from(-7), BigInt::from(2)));
+        assert_eq!(BigInt::from(neg), BigInt::from(-3));
+    }
+
+    #[test]
+    fn test_tryfrom_f64_ok_and_overflow_is_err() {
+        let half = Number::DecimalNumber(BigRational::new(BigInt::from(1), BigInt::from(2)));
+        assert!((f64::try_from(half).unwrap() - 0.5_f64).abs() < f64::EPSILON);
+        // 10^400 exceeds f64::MAX: must error, not silently become infinity.
+        let huge = Number::NaturalNumber(BigInt::from(10).pow(400));
+        assert!(f64::try_from(huge).is_err());
+    }
+
+    #[test]
     fn test_operator_priority() {
         assert_eq!(
             Token::operator_priority(Token::Operator(Operator::Add)),
@@ -645,6 +693,114 @@ mod tests {
         assert_eq!(
             Token::operator_priority(Token::Operator(Operator::Fac)),
             (5, Associate::LeftAssociative)
+        );
+    }
+
+    #[test]
+    fn test_operator_priority_for_assignment() {
+        assert_eq!(
+            Token::operator_priority(Token::Operator(Operator::Eql)),
+            (0, Associate::RightAssociative)
+        );
+    }
+
+    #[test]
+    fn test_tokenize_edge_cases() {
+        assert_eq!(Token::tokenize(""), None);
+        assert_eq!(Token::tokenize("["), Some(Token::Bracket(Bracket::Open)));
+        assert_eq!(Token::tokenize("]"), Some(Token::Bracket(Bracket::Close)));
+        assert_eq!(Token::tokenize(";"), Some(Token::SemiColon));
+        assert_eq!(Token::tokenize(","), Some(Token::Comma));
+        assert_eq!(Token::tokenize("×"), Some(Token::Operator(Operator::Mul)));
+        assert_eq!(Token::tokenize("÷"), Some(Token::Operator(Operator::Div)));
+        assert_eq!(Token::tokenize("foo"), Some(Token::Variable("foo")));
+    }
+
+    #[test]
+    fn test_tokenize_functions_are_case_insensitive() {
+        assert_eq!(
+            Token::tokenize("SIN"),
+            Some(Token::Function(MathFunction::Sin))
+        );
+        assert_eq!(
+            Token::tokenize("Cos"),
+            Some(Token::Function(MathFunction::Cos))
+        );
+        assert_eq!(
+            Token::tokenize("log10"),
+            Some(Token::Function(MathFunction::Log))
+        );
+    }
+
+    #[test]
+    fn test_parse_decimal_literal_variants() {
+        assert_eq!(
+            parse_decimal_literal(".5"),
+            Some(BigRational::new(BigInt::from(1), BigInt::from(2)))
+        );
+        assert_eq!(
+            parse_decimal_literal("1."),
+            Some(BigRational::from_integer(BigInt::from(1)))
+        );
+        assert_eq!(
+            parse_decimal_literal("3.14"),
+            Some(BigRational::new(BigInt::from(157), BigInt::from(50)))
+        );
+        assert_eq!(
+            parse_decimal_literal("0.001"),
+            Some(BigRational::new(BigInt::from(1), BigInt::from(1000)))
+        );
+        // a token without a '.' is not a decimal literal
+        assert_eq!(parse_decimal_literal("42"), None);
+    }
+
+    #[test]
+    fn test_number_display() {
+        assert_eq!(Number::NaturalNumber(BigInt::from(5)).to_string(), "5");
+        // a rational that reduces to a whole number prints as an integer
+        assert_eq!(
+            Number::DecimalNumber(BigRational::new(BigInt::from(4), BigInt::from(2))).to_string(),
+            "2"
+        );
+        assert_eq!(
+            Number::DecimalNumber(BigRational::new(BigInt::from(1), BigInt::from(2))).to_string(),
+            "0.5"
+        );
+        // 1/3 is not a finite decimal, so it is rendered via its f64 approximation
+        let third = Number::DecimalNumber(BigRational::new(BigInt::from(1), BigInt::from(3)));
+        assert_eq!(third.to_string(), format!("{}", 1.0_f64 / 3.0));
+    }
+
+    #[test]
+    fn test_conversion_error_reports_target_type() {
+        let big = Number::NaturalNumber(BigInt::from(2).pow(100));
+        let msg = i32::try_from(big).unwrap_err().to_string();
+        assert!(msg.contains("i32"), "message was: {msg}");
+        assert!(msg.contains("out of range"), "message was: {msg}");
+    }
+
+    #[test]
+    fn test_tryfrom_ok_paths() {
+        assert_eq!(
+            i32::try_from(Number::NaturalNumber(BigInt::from(42))).unwrap(),
+            42_i32
+        );
+        // a decimal is truncated toward zero before the range check
+        assert_eq!(
+            i32::try_from(Number::DecimalNumber(BigRational::new(
+                BigInt::from(7),
+                BigInt::from(2)
+            )))
+            .unwrap(),
+            3_i32
+        );
+        assert_eq!(
+            i128::try_from(Number::NaturalNumber(BigInt::from(2).pow(70))).unwrap(),
+            1_180_591_620_717_411_303_424_i128
+        );
+        assert!(
+            (f64::try_from(Number::NaturalNumber(BigInt::from(10))).unwrap() - 10.0).abs()
+                < f64::EPSILON
         );
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -20,7 +20,7 @@ macro_rules! resolve_decimal {
         let mut resolver = session.process($expr);
         let result = resolver.resolve().unwrap();
         assert!(matches!(result, Number::DecimalNumber(_)));
-        let res_f: f64 = result.clone().into();
+        let res_f: f64 = result.clone().try_into().unwrap();
         assert!((res_f - $expected).abs() < 1e-10);
     }};
     () => {
@@ -192,7 +192,7 @@ fn test_sharing_session() {
     if let (Ok(a), Ok(b)) = (res.resolve(), res2.resolve()) {
         assert!(a == Number::NaturalNumber(BigInt::from(100)));
 
-        let b: i64 = b.into();
+        let b: i64 = b.try_into().unwrap();
         assert!(b == 3265920i64);
     }
 }
@@ -236,6 +236,41 @@ fn test_chained_without_assignment() {
         resolver.resolve().unwrap(),
         Number::NaturalNumber(BigInt::from(7))
     );
+}
+
+#[test]
+fn test_trailing_semicolon_returns_last_value() {
+    // A trailing ';' must return the last completed segment's value, not error.
+    let session = Session::init();
+    let mut resolver = session.process("x=2;");
+    assert_eq!(
+        resolver.resolve().unwrap(),
+        Number::NaturalNumber(BigInt::from(2))
+    );
+}
+
+#[test]
+fn test_trailing_semicolon_does_not_error_after_assignment() {
+    // The assignment side-effect and the reported result must agree: a successful
+    // assignment must not be reported as a malformed-expression error.
+    let session = Session::init();
+    let mut resolver = session.process("a=5;");
+    assert!(resolver.resolve().is_ok());
+
+    let mut reader = session.process("a");
+    assert_eq!(
+        reader.resolve().unwrap(),
+        Number::NaturalNumber(BigInt::from(5))
+    );
+}
+
+#[test]
+fn test_malformed_segment_in_chain_is_rejected() {
+    // A malformed segment ('1 2' is two adjacent operands) must not be silently
+    // discarded by the following ';'.
+    let session = Session::init();
+    let mut resolver = session.process("1 2; 3");
+    assert!(resolver.resolve().is_err());
 }
 
 #[test]
@@ -286,9 +321,137 @@ fn test_builtin_constants_are_read_only() {
     session.set("pi", 0);
 
     let mut resolver = session.process("pi");
-    let pi: f64 = resolver.resolve().unwrap().into();
+    let pi: f64 = resolver.resolve().unwrap().try_into().unwrap();
     assert!((pi - std::f64::consts::PI).abs() < 1e-10);
 
     let mut resolver = session.process("pi=0");
     assert!(resolver.resolve().is_err());
+}
+
+#[test]
+fn test_rounding_functions_on_negative_values() {
+    // floor goes toward -inf, ceil toward +inf, round to nearest (half away from zero).
+    resolve_decimal!("floor(-3.2)", -4.0);
+    resolve_decimal!("ceil(-3.2)", -3.0);
+    resolve_decimal!("round(-3.6)", -4.0);
+    resolve_decimal!("round(-0.5)", -1.0);
+    resolve_decimal!("round(2.5)", 3.0);
+    resolve_decimal!("round(1.5)", 2.0);
+    resolve_decimal!("floor(5.0)", 5.0);
+    resolve_decimal!("ceil(5.0)", 5.0);
+}
+
+#[test]
+fn test_power_edge_cases() {
+    resolve_natural!("0^0", 1);
+    resolve_natural!("5^0", 1);
+    resolve_natural!("2^10", 1024);
+    resolve_natural!("(-2)^3", -8);
+    resolve_natural!("(-2)^2", 4);
+    resolve_natural!("2^64", 18_446_744_073_709_551_616_i128);
+    resolve_decimal!("2^-3", 0.125);
+    // unary minus binds tighter than '^', so -2^2 = (-2)^2 = 4 (documented behaviour).
+    resolve_natural!("-2^2", 4);
+}
+
+#[test]
+fn test_factorial_and_abs_edge_cases() {
+    resolve_natural!("0!", 1);
+    resolve_natural!("1!", 1);
+    resolve_natural!("6!", 720);
+    resolve_decimal!("abs(-2.5)", 2.5);
+    resolve_decimal!("abs(2.5)", 2.5);
+    resolve_decimal!("max(-5,-3)", -3.0);
+    resolve_decimal!("min(-5,-3)", -5.0);
+    resolve_decimal!("exp(0)", 1.0);
+}
+
+#[test]
+fn test_domain_errors_are_rejected() {
+    resolve_err!("sqrt(-1)");
+    resolve_err!("ln(0)");
+    resolve_err!("ln(-5)");
+    resolve_err!("log(0)");
+    resolve_err!("1/0");
+    resolve_err!("5/(3-3)");
+}
+
+#[test]
+fn test_variable_names_are_case_insensitive() {
+    let session = Session::init();
+    let mut resolver = session.process("X=7; x");
+    assert_eq!(
+        resolver.resolve().unwrap(),
+        Number::NaturalNumber(BigInt::from(7))
+    );
+}
+
+#[test]
+fn test_chained_assignment_sets_all_variables() {
+    let session = Session::init();
+    let mut resolver = session.process("x=y=5");
+    assert_eq!(
+        resolver.resolve().unwrap(),
+        Number::NaturalNumber(BigInt::from(5))
+    );
+
+    let mut reader = session.process("x+y");
+    assert_eq!(
+        reader.resolve().unwrap(),
+        Number::NaturalNumber(BigInt::from(10))
+    );
+}
+
+#[test]
+fn test_large_result_to_i64_returns_error_not_panic() {
+    // 2^200 vastly exceeds i64: the public TryFrom must report an error.
+    let session = Session::init();
+    let mut resolver = session.process("2^200");
+    let n = resolver.resolve().unwrap();
+    assert!(i64::try_from(n).is_err());
+}
+
+#[test]
+fn test_square_and_mixed_brackets() {
+    resolve_natural!("[1+2]*3", 9);
+    resolve_natural!("[(1+2)*3]", 9);
+    resolve_natural!("2*[3+[4-1]]", 12);
+}
+
+#[test]
+fn test_whitespace_is_ignored() {
+    resolve_natural!("  1   +   2  ", 3);
+    resolve_natural!("\t3*\t4", 12);
+}
+
+#[test]
+fn test_functions_are_case_insensitive_end_to_end() {
+    resolve_decimal!("COS(0)", 1.0);
+    resolve_decimal!("SqRt(16)", 4.0);
+    resolve_decimal!("LOG10(1000)", 3.0);
+}
+
+#[test]
+fn test_large_factorial_is_exact() {
+    // 20! = 2_432_902_008_176_640_000 (still fits in i64, but is computed exactly via BigInt)
+    resolve_natural!("20!", 2_432_902_008_176_640_000_i64);
+}
+
+#[test]
+fn test_large_power_is_exact() {
+    let session = Session::init();
+    let mut resolver = session.process("2^100");
+    assert_eq!(
+        format!("{}", resolver.resolve().unwrap()),
+        "1267650600228229401496703205376"
+    );
+}
+
+#[test]
+fn test_setf_declares_a_decimal_variable() {
+    let session = Session::init();
+    session.setf("r", 2.5);
+    let mut resolver = session.process("r*2");
+    let v: f64 = resolver.resolve().unwrap().try_into().unwrap();
+    assert!((v - 5.0).abs() < 1e-10);
 }


### PR DESCRIPTION
## Summary

Release 0.2.0. Makes numeric conversions fallible instead of panicking, fixes chained-expression handling, and grows the test suite from 36 to 64 tests.

## Breaking change

`From<Number>` for `i32`/`i64`/`i128`/`f64` panicked on out-of-range or non-finite values. It is replaced by `TryFrom<Number>`, which returns a `ConversionError`. Callers doing `i64::from(n)` must move to `i64::try_from(n)?`.

`From<Number> for BigInt` is kept but is now exact: it truncates the rational toward zero instead of round-tripping through `f64`, so large values no longer lose precision.

## Fixes

- A trailing `;` reported a spurious malformed-expression error *after* the assignment side-effect had already been applied. Chained expressions now return the last segment's value, and genuinely malformed segments are rejected.
- Removed the unused `BitXor` implementation for `Number`, which panicked internally.

## Tests

36 → 64 tests, covering fallible/exact conversions, rounding on negatives, power edge cases, domain errors, variable case-insensitivity, chained assignment, square/mixed brackets, whitespace handling, decimal-literal parsing, and the `Number` `Display` / `ConversionError` messages.

## Verification

`cargo test` passes locally: 28 integration tests, 31 unit tests, 5 doc-tests, 0 failures.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release 0.2.0 makes numeric conversions from `Number` fallible and fixes `;`-chained expressions to return the last segment’s value. It also removes a panicking `BitXor` and expands test coverage.

- **Migration**
  - Replace `into()` calls with `try_into()`/`TryFrom` and handle `ConversionError` (e.g. `let x: i64 = n.try_into()?;`) for `i32`, `i64`, `i128`, and `f64`.
  - `From<Number> for BigInt` stays, and is now exact: it truncates toward zero without an `f64` round-trip.

- **Bug Fixes**
  - Chained expressions: trailing `;` returns the last segment’s value; malformed segments now error; assignment side-effects and reported values are consistent.
  - Removed an unused `BitXor` on `Number` that could panic.

<sup>Written for commit d4e035d4a3e06069fb71f643b9d1022108037638. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davassi/yarer/pull/29?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

