### PR TITLE
Make the evaluation core reliable (Stage 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Example of usage of the library:
 ```
 
 All that's needed is to get a new instance of the 'resolver' from a Session and hand over the expression to be analysed.
-The library returns a natural number or a decimal number if the expression contains a decimal literal (e.g., '2.1+1') or includes a trigonometric function (e.g., 1/cos(x+1)).
+The library returns a `Number`, and the value decides which variant, not the expression that produced it. An integral result always comes back as `Number::NaturalNumber`, whatever it came from — `2.5+2.5` is `5`, `1/cos(0)` is `1`, `6/3` is `2`. `Number::DecimalNumber` appears only when the value genuinely has a fractional part, as in `0.1+0.2` or `1/3`. Every mathematical value therefore has exactly one representation.
 
 ## Variables
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Example of usage of the library:
 
 ```rust
       let session = Session::init();
-      let mut resolver = session.process("1+2"); // or even "(cos(10+e)+3*sin(9/pi))^2" 
+      let mut resolver = session.process("1+2"); // or even "(cos(10+e)+3*sin(9/pi))^2"
 
-      println!("The result is {}", resolver.resolve());
+      println!("The result is {}", resolver.resolve().unwrap());
 ```
 
 All that's needed is to get a new instance of the 'resolver' from a Session and hand over the expression to be analysed.
@@ -35,7 +35,7 @@ Yarer handles variables and functions. Here is an example:
       let mut resolver = session.process("1/cos(x^2)");
 
       session.set("x",1);
-      println!("The result is {}", resolver.resolve());
+      println!("The result is {}", resolver.resolve().unwrap());
 ```
 
 and of course, the expression can be re-evaluated if the variable changes.
@@ -43,10 +43,10 @@ and of course, the expression can be re-evaluated if the variable changes.
 ```rust
       //...
       session.set("x",-1);
-      println!("The result is {}", resolver.resolve());
+      println!("The result is {}", resolver.resolve().unwrap());
 
-      session.set("x",0.001); 
-      println!("The result is {}", resolver.resolve());
+      session.setf("x",0.001);
+      println!("The result is {}", resolver.resolve().unwrap());
       //...
 ```
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ There are many examples of processed expressions in the [integration test file](
     Cdf
 ```
 
+Function arguments are always parenthesised: `sqrt(16)`, `max(1,2)`.
+
 ## Built-in Defined Constants
 
 There are a few predefined math constants available:

--- a/docs/superpowers/plans/2026-08-04-reliable-core.md
+++ b/docs/superpowers/plans/2026-08-04-reliable-core.md
@@ -14,7 +14,7 @@
 - Errors stay `anyhow` strings in this stage. Every new condition gets its own distinct message — never another reuse of `MALFORMED_ERR`. Typed errors are Stage 2.
 - Undefined variables keep evaluating to `0`. Prefix factorial (`!5` → `120`) stays accepted. Both are deliberate exclusions, not oversights.
 - Every task ends with `cargo test` green and `cargo fmt --check` clean.
-- `cargo clippy --all-targets` must not gain warnings. The baseline on `master` is 40, one of which is `this function has too many lines (243/100)` for `resolve()` and must be gone by the end of Task 1.
+- `cargo clippy --all-targets` must not gain warnings. The baseline on `master` is 40, one of which is `this function has too many lines (243/100)` for `resolve()`. Task 1 brings that function down to about 140 lines; it does not put it under the 100-line threshold, and neither that warning nor the one on the extracted function disappears during this stage.
 - Commit messages: imperative subject line, no tool attribution of any kind, no `Co-Authored-By` trailer.
 - Branch: `production-ready-core`, already created, already holding the spec.
 - Do not add dependencies. Everything needed is already in `Cargo.toml`.
@@ -139,11 +139,18 @@ In `src/rpn_resolver.rs`, add `use crate::functions;` to the existing `use crate
 Run: `cargo test 2>&1 | grep "^test result"`
 Expected: exactly the four lines recorded in Step 1. **No test file was edited** — `git status` must show no changes under `tests/`.
 
-Run: `cargo clippy --all-targets 2>&1 | grep "too many lines"`
-Expected: no output. `resolve()` is now roughly 140 lines.
-
 Run: `cargo clippy --all-targets 2>&1 | grep -c "^warning:"`
 Expected: 40 or fewer. If it grew, fix what was introduced before committing.
+
+Run: `cargo clippy --all-targets 2>&1 | grep -A2 "too many lines"`
+Expected: `resolve()` has dropped from 243 lines to about 140.
+
+It is still over clippy's 100-line threshold, and so is the extracted `eval()` at
+about 102 — splitting a 243-line function into 141 + 102 cannot put either under 100,
+and Tasks 3 and 4 add lines to both. The warning therefore does not disappear at this
+task, or at this stage. What must hold is that the **total** warning count does not
+grow. Beware that a stable total can hide movement in both directions: check the
+per-function line counts above, not only the count.
 
 Run: `cargo fmt --check`
 Expected: clean.
@@ -1182,7 +1189,7 @@ count within."
 
 - [ ] `cargo test` green, with the new tests from all four tasks.
 - [ ] `test_chained_assignment_sets_all_variables` (`x=y=5` sets both and returns 5) and `test_chained_expressions` (`x=2; y=3; x*y` returns 6) still pass untouched. The spec names them because they are load-bearing behaviour that none of these four changes may disturb.
-- [ ] `cargo clippy --all-targets` at or below 40 warnings, with `too many lines` gone.
+- [ ] `cargo clippy --all-targets` at or below 40 warnings, checked per-category rather than by the total alone.
 - [ ] `cargo fmt --check` clean.
 - [ ] The measured `max_value_bits` figure and its timing recorded in the spec.
 - [ ] The three declared behaviour changes gathered for the 0.3.0 CHANGELOG: integral results now come back as `NaturalNumber`, oversized results are refused, parentheses after a function name are mandatory.

--- a/docs/superpowers/plans/2026-08-04-reliable-core.md
+++ b/docs/superpowers/plans/2026-08-04-reliable-core.md
@@ -1,0 +1,1188 @@
+# Reliable Core Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the four reliability defects in yarer's evaluation core — factorial rejecting integral decimals, `Number` violating the `PartialEq`/`PartialOrd` contract, factorial and power never terminating on large operands, and function arity never being validated.
+
+**Architecture:** Four changes in a fixed order. First a pure extraction that moves function evaluation out of the 243-line `resolve()` into its own module, guarded by the existing suite. Then a canonical representation for `Number` that makes "an integral value tagged as decimal" unrepresentable. Then size limits that predict the size of a result and refuse before computing it. Finally argument counting inside the shunting yard.
+
+**Tech Stack:** Rust 2021. `num-bigint`/`num-rational` for exact arithmetic, `num-traits` for the numeric predicates, `statrs` for the normal distribution, `anyhow` for errors, `rustyline`+`clap` for the binary.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-08-04-reliable-core-design.md`. Read it before starting.
+- Errors stay `anyhow` strings in this stage. Every new condition gets its own distinct message — never another reuse of `MALFORMED_ERR`. Typed errors are Stage 2.
+- Undefined variables keep evaluating to `0`. Prefix factorial (`!5` → `120`) stays accepted. Both are deliberate exclusions, not oversights.
+- Every task ends with `cargo test` green and `cargo fmt --check` clean.
+- `cargo clippy --all-targets` must not gain warnings. The baseline on `master` is 40, one of which is `this function has too many lines (243/100)` for `resolve()` and must be gone by the end of Task 1.
+- Commit messages: imperative subject line, no tool attribution of any kind, no `Co-Authored-By` trailer.
+- Branch: `production-ready-core`, already created, already holding the spec.
+- Do not add dependencies. Everything needed is already in `Cargo.toml`.
+
+---
+
+### Task 1: Extract function evaluation into its own module
+
+Component D of the spec. This is a **pure move with no behaviour change**: the existing 64 tests are the proof, and they must be green before and after with no edits to any test.
+
+**Files:**
+- Create: `src/functions.rs`
+- Modify: `src/lib.rs` (add the module declaration)
+- Modify: `src/rpn_resolver.rs` — the `Token::Function` arm at `:186-299`, the helpers at `:488-517`, and the three error statics at `:21-32`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces, all `pub(crate)` in `crate::functions`:
+  - `eval(fun: MathFunction, value: Number, result_stack: &mut VecDeque<Number>, var_stack: &mut VecDeque<Option<String>>) -> anyhow::Result<Number>`
+  - `number_to_f64(value: &Number, error_message: &'static str) -> anyhow::Result<f64>`
+  - `decimal_from_f64(value: f64, error_message: &'static str) -> anyhow::Result<Number>`
+  - `number_to_rational(value: Number) -> BigRational`
+  - `to_decimal_number(value: Number) -> Number`
+
+- [ ] **Step 1: Record the baseline**
+
+Run: `cargo test 2>&1 | grep "^test result"`
+Expected: four lines, `31 passed`, `0 passed`, `28 passed`, `5 passed; 0 failed; 2 ignored`. Write the numbers down — they must be identical at Step 6.
+
+Run: `cargo clippy --all-targets 2>&1 | grep -c "^warning:"`
+Expected: `40`.
+
+- [ ] **Step 2: Widen the three error statics that the new module needs**
+
+In `src/rpn_resolver.rs`, change the visibility of exactly these three, leaving the others untouched:
+
+```rust
+pub(crate) static MALFORMED_ERR: &str = "Runtime Error: The mathematical expression is malformed.";
+pub(crate) static INVALID_FUNCTION_RESULT_ERR: &str = "Runtime error: Function result is not a real number.";
+pub(crate) static FLOAT_EVAL_TOO_LARGE_ERR: &str = "Runtime error: Operand is too large for floating-point evaluation.";
+```
+
+They are imported by the new module rather than copied. Duplicating an error string is how two messages silently drift apart.
+
+- [ ] **Step 3: Create `src/functions.rs`**
+
+Write this header, then **move** — cut, do not retype — the body of the `match fun { … }` expression currently at `src/rpn_resolver.rs:194-296` into the `match` below, and the four helper functions currently at `src/rpn_resolver.rs:488-517` beneath it, changing each helper's declaration from `fn name(…)` to `pub(crate) fn name(…)` and dropping the `Self::` qualifier from every internal call.
+
+```rust
+//! Evaluation of the built-in mathematical functions, together with the
+//! numeric conversions they rely on.
+//!
+//! Split out of [`crate::rpn_resolver`], which owns the shunting-yard
+//! translation and the evaluation loop; this module owns what happens when
+//! that loop meets a [`MathFunction`].
+
+use crate::rpn_resolver::{FLOAT_EVAL_TOO_LARGE_ERR, INVALID_FUNCTION_RESULT_ERR, MALFORMED_ERR};
+use crate::token::{MathFunction, Number};
+use anyhow::anyhow;
+use num::{Integer, Signed};
+use num_bigint::BigInt;
+use num_rational::BigRational;
+use num_traits::{ToPrimitive, Zero};
+use statrs::distribution::{Continuous, ContinuousCDF, Normal};
+use std::collections::VecDeque;
+
+/// Evaluates `fun` against `value`, the operand already popped by the caller.
+///
+/// A two-argument function pops its second operand from `result_stack` itself,
+/// keeping `var_stack` in step. Both stacks belong to the evaluation loop in
+/// [`crate::rpn_resolver::RpnResolver::resolve`].
+pub(crate) fn eval(
+    fun: MathFunction,
+    value: Number,
+    result_stack: &mut VecDeque<Number>,
+    var_stack: &mut VecDeque<Option<String>>,
+) -> anyhow::Result<Number> {
+    let result = match fun {
+        // ... moved verbatim from rpn_resolver.rs:194-296 ...
+    };
+    Ok(result)
+}
+```
+
+Three mechanical adjustments while moving, and nothing else:
+1. `MathFunction::Sin => …` etc. match on `fun` by value now, not on `&fun`, so the arms lose no patterns but the leading `*` disappears if present.
+2. Calls of the form `Self::decimal_from_f64(…)`, `Self::number_to_f64(…)`, `Self::number_to_rational(…)`, `Self::to_decimal_number(…)` become bare `decimal_from_f64(…)` and so on.
+3. `result_stack` and `var_stack` are already the parameter names used in the moved code, so the `Max` and `Min` arms need no edit.
+
+- [ ] **Step 4: Declare the module and rewrite the call site**
+
+In `src/lib.rs`, after the existing `/// Parser` / `pub mod parser;` pair, add:
+
+```rust
+/// Built-in function evaluation
+mod functions;
+```
+
+It is private: nothing outside the crate calls it.
+
+In `src/rpn_resolver.rs`, add `use crate::functions;` to the existing `use crate::{…}` group, delete the four helper functions at `:488-517`, and replace the whole `Token::Function(fun) => { … }` arm with:
+
+```rust
+                Token::Function(fun) => {
+                    let value: Number = result_stack.pop_back().ok_or(anyhow!(
+                        "{} {}",
+                        MALFORMED_ERR,
+                        "Wrong use of function"
+                    ))?;
+                    var_stack.pop_back();
+
+                    let result = functions::eval(*fun, value, &mut result_stack, &mut var_stack)?;
+                    result_stack.push_back(result);
+                    var_stack.push_back(None);
+                }
+```
+
+`power` and `power_integer` still call `number_to_f64` and `decimal_from_f64`, so add `use crate::functions::{decimal_from_f64, number_to_f64};` and drop the `Self::` prefix at those three call sites (`:532`, `:533`, `:534`).
+
+- [ ] **Step 5: Verify nothing moved but the code**
+
+Run: `cargo test 2>&1 | grep "^test result"`
+Expected: exactly the four lines recorded in Step 1. **No test file was edited** — `git status` must show no changes under `tests/`.
+
+Run: `cargo clippy --all-targets 2>&1 | grep "too many lines"`
+Expected: no output. `resolve()` is now roughly 140 lines.
+
+Run: `cargo clippy --all-targets 2>&1 | grep -c "^warning:"`
+Expected: 40 or fewer. If it grew, fix what was introduced before committing.
+
+Run: `cargo fmt --check`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/functions.rs src/lib.rs src/rpn_resolver.rs
+git commit -m "Move function evaluation into its own module
+
+resolve() was 243 lines and clippy flagged it. The MathFunction dispatch
+and the numeric conversions it needs now live in src/functions.rs, leaving
+the shunting-yard translation and the evaluation loop in rpn_resolver.
+
+Pure move: no behaviour change, no test edited, same 64 tests green."
+```
+
+---
+
+### Task 2: Canonical `Number`
+
+Component A of the spec. Closes defect 1 (`abs(-3)!` fails) and defect 2 (`PartialEq`/`PartialOrd` disagree).
+
+**Invariant introduced: `Number::DecimalNumber` never holds a rational whose denominator is 1.**
+
+**Files:**
+- Modify: `src/token.rs` — the derive at `:12`, `Div` at `:335-354`, `apply_functional_token_operation` at `:294-309`, `tokenize` at `:222-224`; add an `impl Number` block and a `PartialEq` impl
+- Modify: `src/functions.rs` — `decimal_from_f64`, and delete `to_decimal_number` along with its five call sites
+- Modify: `src/rpn_resolver.rs` — the `Operator::Fac` arm, `integer_exponent` and `power_integer`
+- Modify: `src/session.rs` — `init_local_heap`, `setf`
+- Test: `tests/integration_tests.rs` — the `resolve_decimal!` macro at `:17-28`, plus two new tests
+- Test: `src/token.rs` — new unit tests in the existing `mod tests`
+
+**Interfaces:**
+- Consumes: `crate::functions::{decimal_from_f64, to_decimal_number}` from Task 1.
+- Produces:
+  - `Number::decimal(value: BigRational) -> Number` — public, the only sanctioned way to build a decimal
+  - `Number::as_integer(&self) -> Option<BigInt>` — public, `Some` when the value is a whole number
+  - `to_decimal_number` no longer exists
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `mod tests` in `src/token.rs`:
+
+```rust
+    #[test]
+    fn test_decimal_constructor_degrades_integral_rationals() {
+        // 4/2 reduces to 2, which is an integer: it must not stay tagged as decimal.
+        let n = Number::decimal(BigRational::new(BigInt::from(4), BigInt::from(2)));
+        assert_eq!(n, Number::NaturalNumber(BigInt::from(2)));
+        assert!(matches!(n, Number::NaturalNumber(_)));
+
+        // 1/2 is not integral and must stay decimal.
+        let half = Number::decimal(BigRational::new(BigInt::from(1), BigInt::from(2)));
+        assert!(matches!(half, Number::DecimalNumber(_)));
+    }
+
+    #[test]
+    fn test_as_integer_reads_the_value_not_the_tag() {
+        assert_eq!(
+            Number::NaturalNumber(BigInt::from(7)).as_integer(),
+            Some(BigInt::from(7))
+        );
+        // Built by hand, bypassing the constructor: the value is still integral.
+        assert_eq!(
+            Number::DecimalNumber(BigRational::from_integer(BigInt::from(7))).as_integer(),
+            Some(BigInt::from(7))
+        );
+        assert_eq!(
+            Number::DecimalNumber(BigRational::new(BigInt::from(3), BigInt::from(2))).as_integer(),
+            None
+        );
+    }
+
+    #[test]
+    fn test_eq_agrees_with_partial_cmp_across_variants() {
+        use std::cmp::Ordering;
+        let pairs = [
+            (
+                Number::NaturalNumber(BigInt::from(2)),
+                Number::DecimalNumber(BigRational::from_integer(BigInt::from(2))),
+            ),
+            (
+                Number::NaturalNumber(BigInt::from(-3)),
+                Number::DecimalNumber(BigRational::new(BigInt::from(-6), BigInt::from(2))),
+            ),
+            (
+                Number::NaturalNumber(BigInt::from(2)),
+                Number::DecimalNumber(BigRational::new(BigInt::from(5), BigInt::from(2))),
+            ),
+        ];
+        for (a, b) in pairs {
+            let equal_by_eq = a == b;
+            let equal_by_ord = a.partial_cmp(&b) == Some(Ordering::Equal);
+            assert_eq!(
+                equal_by_eq, equal_by_ord,
+                "PartialEq and PartialOrd disagree on {a} vs {b}"
+            );
+        }
+    }
+```
+
+Append to `tests/integration_tests.rs`:
+
+```rust
+#[test]
+fn test_factorial_accepts_integral_results_of_functions() {
+    // These all produced "Factorial is only defined for non-negative integers"
+    // before the Number invariant, because the functions tagged an integral
+    // result as decimal and the factorial branched on the tag.
+    resolve_natural!("abs(-3)!", 6);
+    resolve_natural!("floor(2.5)!", 2);
+    resolve_natural!("max(3,2)!", 6);
+    resolve_natural!("round(2.4)!", 2);
+    resolve_natural!("(6/3)!", 2);
+}
+
+#[test]
+fn test_integral_results_are_natural_numbers() {
+    let session = Session::init();
+    for expr in ["6/3", "floor(3.7)", "exp(0)", "max(1,2)", "sqrt(16)"] {
+        let mut resolver = session.process(expr);
+        let result = resolver.resolve().unwrap();
+        assert!(
+            matches!(result, Number::NaturalNumber(_)),
+            "{expr} produced {result:?}, expected a NaturalNumber"
+        );
+    }
+}
+
+#[test]
+fn test_non_integral_results_stay_decimal() {
+    let session = Session::init();
+    for expr in ["1/3", "abs(-2.5)", "2^-3", "sqrt(2)"] {
+        let mut resolver = session.process(expr);
+        let result = resolver.resolve().unwrap();
+        assert!(
+            matches!(result, Number::DecimalNumber(_)),
+            "{expr} produced {result:?}, expected a DecimalNumber"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run: `cargo test test_decimal_constructor_degrades_integral_rationals`
+Expected: FAIL — `no function or associated item named 'decimal' found`.
+
+Run: `cargo test --test integration_tests test_factorial_accepts_integral_results_of_functions`
+Expected: FAIL — the assertion reports the factorial error message.
+
+Run: `cargo test test_eq_agrees_with_partial_cmp_across_variants`
+Expected: FAIL — `PartialEq and PartialOrd disagree on 2 vs 2`. (This one is a unit test inside the library, so it takes no `--test` flag.)
+
+- [ ] **Step 3: Add the constructor, the accessor and value-based equality**
+
+In `src/token.rs`, remove `PartialEq` from the derive on `Number` at `:12`:
+
+```rust
+#[derive(Debug, Clone)]
+pub enum Number {
+```
+
+Add, next to the existing `impl Display for Number`:
+
+```rust
+impl Number {
+    /// Builds a decimal number, degrading to [`Number::NaturalNumber`] when the
+    /// rational turns out to be a whole number.
+    ///
+    /// This is the only sanctioned way to build a [`Number::DecimalNumber`]:
+    /// it upholds the invariant that a decimal never carries a denominator of 1,
+    /// so a given mathematical value has exactly one representation.
+    #[must_use]
+    pub fn decimal(value: BigRational) -> Number {
+        if value.denom().is_one() {
+            Number::NaturalNumber(value.to_integer())
+        } else {
+            Number::DecimalNumber(value)
+        }
+    }
+
+    /// Returns the integral value of this number, or [`None`] when it has a
+    /// fractional part.
+    ///
+    /// The decimal arm matters only for values built by hand from outside the
+    /// crate, which can bypass [`Number::decimal`]; internally the invariant
+    /// makes it unreachable.
+    #[must_use]
+    pub fn as_integer(&self) -> Option<BigInt> {
+        match self {
+            Number::NaturalNumber(v) => Some(v.clone()),
+            Number::DecimalNumber(v) if v.denom().is_one() => Some(v.to_integer()),
+            Number::DecimalNumber(_) => None,
+        }
+    }
+}
+
+/// Equality by mathematical value, so that it agrees with [`PartialOrd`].
+///
+/// The derived implementation compared enum variants, which made
+/// `NaturalNumber(2) == DecimalNumber(2/1)` false while `>=` reported true —
+/// a violation of the `PartialOrd` contract that generic code relies on.
+impl PartialEq for Number {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Number::NaturalNumber(a), Number::NaturalNumber(b)) => a == b,
+            (Number::DecimalNumber(a), Number::DecimalNumber(b)) => a == b,
+            (Number::NaturalNumber(a), Number::DecimalNumber(b))
+            | (Number::DecimalNumber(b), Number::NaturalNumber(a)) => {
+                BigRational::from(a.clone()) == *b
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Route every decimal construction through the constructor**
+
+`src/token.rs`, `Div` at `:335-354` — all four arms:
+
+```rust
+impl Div for Number {
+    type Output = Number;
+
+    fn div(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (Number::NaturalNumber(v1), Number::NaturalNumber(v2)) => {
+                Number::decimal(BigRational::new(v1, v2))
+            }
+            (Number::NaturalNumber(v1), Number::DecimalNumber(v2)) => {
+                Number::decimal(BigRational::from(v1) / v2)
+            }
+            (Number::DecimalNumber(v1), Number::NaturalNumber(v2)) => {
+                Number::decimal(v1 / BigRational::from(v2))
+            }
+            (Number::DecimalNumber(v1), Number::DecimalNumber(v2)) => Number::decimal(v1 / v2),
+        }
+    }
+}
+```
+
+`src/token.rs`, `apply_functional_token_operation` at `:294-309` — the three arms that produce a decimal:
+
+```rust
+        (Number::NaturalNumber(v1), Number::NaturalNumber(v2)) => Number::NaturalNumber(nf(v1, v2)),
+        (Number::NaturalNumber(v1), Number::DecimalNumber(v2)) => {
+            Number::decimal(df(BigRational::from(v1), v2))
+        }
+        (Number::DecimalNumber(v1), Number::NaturalNumber(v2)) => {
+            Number::decimal(df(v1, BigRational::from(v2)))
+        }
+        (Number::DecimalNumber(v1), Number::DecimalNumber(v2)) => Number::decimal(df(v1, v2)),
+```
+
+`src/token.rs`, `tokenize` at `:222-224`:
+
+```rust
+        if let Some(v) = parse_decimal_literal(t) {
+            return Some(Token::Operand(Number::decimal(v)));
+        }
+```
+
+`src/functions.rs`, `decimal_from_f64`:
+
+```rust
+pub(crate) fn decimal_from_f64(value: f64, error_message: &'static str) -> anyhow::Result<Number> {
+    if !value.is_finite() {
+        return Err(anyhow!(error_message));
+    }
+
+    BigRational::from_float(value)
+        .map(Number::decimal)
+        .ok_or_else(|| anyhow!(error_message))
+}
+```
+
+`src/session.rs` — `init_local_heap` builds the five constants and `setf` stores a float. Replace every `Number::DecimalNumber(x)` with `Number::decimal(x)` in both. None of the five constants is integral, so the constants are unaffected in practice; the change keeps a single construction path.
+
+`src/rpn_resolver.rs`, `power_integer` at `:537-577` — the three `Number::DecimalNumber(…)` constructions become `Number::decimal(…)`:
+
+```rust
+                    let value = Self::pow_big_int(base, exponent);
+                    Ok(Number::decimal(BigRational::new(BigInt::one(), value)))
+```
+
+```rust
+                let value = Self::pow_big_rational(base, exponent);
+                if is_negative {
+                    Ok(Number::decimal(value.recip()))
+                } else {
+                    Ok(Number::decimal(value))
+                }
+```
+
+- [ ] **Step 5: Delete `to_decimal_number` and fix the factorial**
+
+In `src/functions.rs`, delete the `to_decimal_number` function and unwrap its five call sites, which become the value itself:
+
+- `Abs`: `match value { Number::NaturalNumber(v) => Number::NaturalNumber(v.abs()), Number::DecimalNumber(v) => Number::decimal(v.abs()) }`
+- `Max`: `if value >= value2 { value } else { value2 }`
+- `Min`: `if value <= value2 { value } else { value2 }`
+- `Floor`, `Ceil`, `Round`: `Number::NaturalNumber(…)` directly, dropping the wrapper
+
+In `src/rpn_resolver.rs`, replace the whole `Operator::Fac` arm:
+
+```rust
+                        Operator::Fac => {
+                            // Factorial is defined on non-negative integers. It asks the
+                            // value, not the enum tag: floor(2.5) and 6/3 are integers.
+                            let n = right_value
+                                .as_integer()
+                                .ok_or_else(|| anyhow!(FACTORIAL_NATURAL_ERR))?;
+                            if n < BigInt::zero() {
+                                return Err(anyhow!(FACTORIAL_NATURAL_ERR));
+                            }
+                            let n = n.to_u64().ok_or_else(|| {
+                                anyhow!("Runtime Error: Factorial operand is too large")
+                            })?;
+                            let res = Self::factorial_helper(n.into());
+                            result_stack.push_back(Number::NaturalNumber(res.into()));
+                            var_stack.push_back(None);
+                        }
+```
+
+Delete `integer_exponent` at `:519-525` and change `power` to use the accessor:
+
+```rust
+    fn power(left_value: Number, right_value: Number) -> anyhow::Result<Number> {
+        if let Some(exponent) = right_value.as_integer() {
+            return Self::power_integer(left_value, exponent);
+        }
+
+        let base = number_to_f64(&left_value, POWER_TOO_LARGE_ERR)?;
+        let exponent = number_to_f64(&right_value, POWER_TOO_LARGE_ERR)?;
+        decimal_from_f64(base.powf(exponent), INVALID_POWER_ERR)
+    }
+```
+
+- [ ] **Step 6: Stop the test macro asserting the enum variant**
+
+In `tests/integration_tests.rs:17-28`, remove the `matches!` line from `resolve_decimal!` and say why:
+
+```rust
+/// Asserts the numeric value of an expression, within 1e-10.
+///
+/// It deliberately does not assert which `Number` variant came back: under the
+/// canonicalisation invariant an integral result is a `NaturalNumber`, and
+/// which side of that line an expression falls on is asserted once, on purpose,
+/// by `test_integral_results_are_natural_numbers`.
+macro_rules! resolve_decimal {
+    ($expr:expr, $expected:expr) => {{
+        let session = Session::init();
+        let mut resolver = session.process($expr);
+        let result = resolver.resolve().unwrap();
+        let res_f: f64 = result.try_into().unwrap();
+        assert!((res_f - $expected).abs() < 1e-10);
+    }};
+    () => {
+        panic!("Expected a decimal number, but got an invalid result.");
+    };
+}
+```
+
+Note `result.try_into()` no longer needs the `clone()`, since `result` is not used afterwards.
+
+- [ ] **Step 7: Run the whole suite**
+
+Run: `cargo test`
+Expected: all green, with 3 new unit tests in `token.rs` and 3 new integration tests, so `34 passed` and `31 passed`.
+
+If `test_max_min` in `src/rpn_resolver.rs` fails, read the failure before touching it: it uses `assert_eq!` against `DecimalNumber(2.0)`, which value-based equality should now satisfy against `NaturalNumber(2)`. A failure there means `PartialEq` is wrong, not the test.
+
+Run: `cargo clippy --all-targets 2>&1 | grep -c "^warning:"`
+Expected: no higher than after Task 1.
+
+Run: `cargo fmt --check`
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A src tests
+git commit -m "Give every numeric value one representation
+
+NaturalNumber(2) and DecimalNumber(2/1) meant the same number, and code
+branched on the tag rather than the value. Two defects followed: factorial
+rejected abs(-3), floor(2.5) and max(3,2), because those functions forced
+the decimal tag onto integral results; and Number violated the PartialOrd
+contract, with 2 == 2/1 false while 2 >= 2/1 was true.
+
+Number::decimal is now the only way to build a decimal and degrades an
+integral rational to NaturalNumber, Number::as_integer replaces the two
+copies of the is-this-a-whole-number test, and PartialEq compares values."
+```
+
+---
+
+### Task 3: Size limits
+
+Component B of the spec. Closes defect 3: `999999999!` and `10^100000000` never return.
+
+**Files:**
+- Create: `src/limits.rs`
+- Modify: `src/lib.rs` (declare the module, publicly)
+- Modify: `src/session.rs` (a `limits` field, `with_limits`, pass it to the resolver)
+- Modify: `src/rpn_resolver.rs` (a `limits` field, the arithmetic arms, `power_integer`, the factorial arm, the `test_resolve` unit test's struct literal)
+- Test: `tests/integration_tests.rs`
+
+**Interfaces:**
+- Consumes: `Number::as_integer` from Task 2.
+- Produces:
+  - `limits::Limits { pub max_value_bits: u64 }`, `Copy`, with `Default` giving `1 << 20`
+  - `limits::size_in_bits(value: &Number) -> u64`
+  - `limits::check_size(value: &Number, limits: Limits) -> anyhow::Result<()>`
+  - `limits::check_predicted_size(predicted_bits: u128, limits: Limits) -> anyhow::Result<()>`
+  - `Session::with_limits(limits: Limits) -> Session`
+  - `RpnResolver::parse_with_borrowed_heap(exp, borrowed_heap, limits)` — one extra parameter, a breaking change to a public method
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/integration_tests.rs`:
+
+```rust
+#[test]
+fn test_oversized_factorial_is_refused_not_computed() {
+    // Before the limit this did not return at all. The test is its own alarm:
+    // if the guard stops working, the suite hangs here instead of failing.
+    let session = Session::init();
+    let mut resolver = session.process("999999999!");
+    let err = resolver.resolve().unwrap_err().to_string();
+    assert!(err.contains("size limit"), "message was: {err}");
+}
+
+#[test]
+fn test_oversized_power_is_refused_not_computed() {
+    let session = Session::init();
+    let mut resolver = session.process("10^100000000");
+    let err = resolver.resolve().unwrap_err().to_string();
+    assert!(err.contains("size limit"), "message was: {err}");
+}
+
+#[test]
+fn test_legitimate_big_values_still_pass_the_default_limit() {
+    resolve_natural!("2^64", 18_446_744_073_709_551_616_i128);
+    let session = Session::init();
+    let mut resolver = session.process("1000!");
+    // 1000! needs about 8530 bits, comfortably inside the default budget.
+    assert!(resolver.resolve().is_ok());
+}
+
+#[test]
+fn test_the_limit_is_configurable() {
+    let session = Session::with_limits(Limits { max_value_bits: 64 });
+    let mut resolver = session.process("2^100");
+    assert!(resolver.resolve().is_err(), "2^100 needs 101 bits, over a 64-bit budget");
+
+    let mut small = session.process("2^10");
+    assert!(small.resolve().is_ok());
+}
+
+#[test]
+fn test_growth_through_multiplication_is_caught() {
+    // 2^3000 occupies 3001 bits and is admitted; squaring it needs 6001, which
+    // is not. Each step is individually under budget only until it is not.
+    let session = Session::with_limits(Limits { max_value_bits: 4096 });
+    let mut resolver = session.process("x=2^3000; x*x");
+    assert!(resolver.resolve().is_err(), "the product needs 6001 bits");
+}
+```
+
+Add `use yarer::limits::Limits;` to the imports at the top of the file.
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `cargo test --test integration_tests test_the_limit_is_configurable`
+Expected: FAIL to compile — `unresolved import 'yarer::limits'`.
+
+Do **not** run `test_oversized_factorial_is_refused_not_computed` yet: without the guard it does not terminate.
+
+- [ ] **Step 3: Create `src/limits.rs`**
+
+```rust
+//! Bounds on how large a value an evaluation may produce.
+//!
+//! The strategy is to predict the size of a result and refuse before computing
+//! it, rather than computing under a timeout: no threads, no interruption, and
+//! a decision that is deterministic and instantaneous.
+
+use crate::token::Number;
+use anyhow::anyhow;
+
+/// Resource bounds applied while evaluating an expression.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Limits {
+    /// The largest value any intermediate or final result may occupy, in bits.
+    pub max_value_bits: u64,
+}
+
+impl Default for Limits {
+    /// 1 Mibit, roughly 315_000 decimal digits.
+    fn default() -> Self {
+        Limits {
+            max_value_bits: 1 << 20,
+        }
+    }
+}
+
+/// The size of a value in bits: for a rational, numerator plus denominator.
+#[must_use]
+pub fn size_in_bits(value: &Number) -> u64 {
+    match value {
+        Number::NaturalNumber(v) => v.bits(),
+        Number::DecimalNumber(v) => v.numer().bits() + v.denom().bits(),
+    }
+}
+
+/// Rejects a value that has already been computed and turned out too large.
+///
+/// # Errors
+/// When the value exceeds `limits.max_value_bits`.
+pub fn check_size(value: &Number, limits: Limits) -> anyhow::Result<()> {
+    check_predicted_size(u128::from(size_in_bits(value)), limits)
+}
+
+/// Rejects a computation whose result was predicted to be too large, before it runs.
+///
+/// # Errors
+/// When `predicted_bits` exceeds `limits.max_value_bits`.
+pub fn check_predicted_size(predicted_bits: u128, limits: Limits) -> anyhow::Result<()> {
+    if predicted_bits > u128::from(limits.max_value_bits) {
+        return Err(anyhow!(
+            "Runtime error: the result would need about {predicted_bits} bits, over the size limit of {} bits.",
+            limits.max_value_bits
+        ));
+    }
+    Ok(())
+}
+
+/// Predicts the bit length of `n!` without computing it, via Stirling:
+/// `log2(n!) ≈ n·log2(n) − 1.44·n`.
+#[must_use]
+pub fn predicted_factorial_bits(n: u64) -> u128 {
+    if n < 2 {
+        return 1;
+    }
+    let n_f = n as f64;
+    let bits = n_f.mul_add(n_f.log2(), -1.442_695_040_888_963_4 * n_f);
+    // Round up and never report less than one bit.
+    bits.max(1.0).ceil() as u128
+}
+
+/// An upper bound on the bit length of `base^exponent` for an integral exponent.
+///
+/// It uses `bits(base)` where `log2(base)` would be exact, so it overestimates by
+/// up to a factor of two for small bases — `2^100` is predicted at 200 bits and
+/// occupies 101. A guard that errs toward refusing is the right direction to err in,
+/// and the discrepancy only matters within a factor of two of the budget.
+#[must_use]
+pub fn predicted_power_bits(base: &Number, exponent_magnitude: u64) -> u128 {
+    let base_bits = size_in_bits(base).max(1);
+    u128::from(base_bits) * u128::from(exponent_magnitude)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use num_bigint::BigInt;
+    use num_rational::BigRational;
+
+    #[test]
+    fn test_size_of_a_rational_counts_both_halves() {
+        let third = Number::DecimalNumber(BigRational::new(BigInt::from(1), BigInt::from(3)));
+        assert_eq!(size_in_bits(&third), 1 + 2);
+    }
+
+    #[test]
+    fn test_factorial_prediction_is_in_the_right_ballpark() {
+        // 1000! is 8529 bits; Stirling must land close and never far under.
+        let predicted = predicted_factorial_bits(1000);
+        assert!(
+            (8000..=9200).contains(&predicted),
+            "predicted {predicted} bits for 1000!"
+        );
+    }
+
+    #[test]
+    fn test_power_prediction_multiplies_base_size_by_exponent() {
+        let ten = Number::NaturalNumber(BigInt::from(10));
+        assert_eq!(predicted_power_bits(&ten, 100), 400);
+    }
+
+    #[test]
+    fn test_check_rejects_above_the_budget_and_accepts_at_it() {
+        let limits = Limits { max_value_bits: 64 };
+        assert!(check_predicted_size(64, limits).is_ok());
+        assert!(check_predicted_size(65, limits).is_err());
+    }
+}
+```
+
+- [ ] **Step 4: Thread the limits through `Session` and `RpnResolver`**
+
+`src/lib.rs`:
+
+```rust
+/// Evaluation limits
+pub mod limits;
+```
+
+`src/session.rs` — add the field and the constructor, and pass the value on:
+
+```rust
+pub struct Session {
+    variable_heap: Rc<RefCell<HashMap<String, Number>>>,
+    limits: Limits,
+}
+```
+
+```rust
+    #[must_use]
+    pub fn init() -> Session {
+        Session::with_limits(Limits::default())
+    }
+
+    /// Builds a session whose evaluations are bound by `limits`.
+    #[must_use]
+    pub fn with_limits(limits: Limits) -> Session {
+        Session {
+            variable_heap: Rc::new(RefCell::new(Session::init_local_heap())),
+            limits,
+        }
+    }
+```
+
+```rust
+    #[must_use]
+    pub fn process<'a>(&'a self, line: &'a str) -> RpnResolver<'a> {
+        let clone = Rc::clone(&self.variable_heap);
+        RpnResolver::parse_with_borrowed_heap(line, clone, self.limits)
+    }
+```
+
+`src/rpn_resolver.rs` — the struct, both construction arms, and the signature:
+
+```rust
+pub struct RpnResolver<'a> {
+    rpn_expr: VecDeque<Token<'a>>,
+    local_heap: Rc<RefCell<HashMap<String, Number>>>,
+    build_error: Option<String>,
+    limits: Limits,
+}
+```
+
+```rust
+    pub fn parse_with_borrowed_heap<'a>(
+        exp: &'a str,
+        borrowed_heap: Rc<RefCell<HashMap<String, Number>>>,
+        limits: Limits,
+    ) -> RpnResolver<'a> {
+```
+
+Both the `Ok` and the `Err` arm of that function gain `limits,` in the struct literal. The `test_resolve` unit test at the bottom of the file builds an `RpnResolver` literally and needs `limits: Limits::default(),` too.
+
+`parse_with_borrowed_heap` is public, but `src/session.rs:42` is its only caller in the repository — verified by grep across sources, tests and docs. Nothing else needs updating.
+
+- [ ] **Step 5: Apply the checks**
+
+Add the imports first: `use crate::limits::{self, Limits};` in `src/rpn_resolver.rs`, and `use crate::limits::Limits;` in `src/session.rs`.
+
+In `resolve()`, the four arithmetic arms check the result they just produced. The loop runs over `&self.rpn_expr`, which borrows `self`, so a `self.check(…)` method would not borrow-check inside it. Copy the limits into a local before the loop and call the free function:
+
+```rust
+        let limits = self.limits;
+```
+
+then each arm becomes, for example:
+
+```rust
+                        Operator::Add => {
+                            let value = left_value + right_value;
+                            limits::check_size(&value, limits)?;
+                            result_stack.push_back(value);
+                            var_stack.push_back(None);
+                        }
+```
+
+Apply the same shape to `Sub`, `Mul` and `Div` — for `Div`, after the existing divide-by-zero guard.
+
+The factorial arm checks before computing, right after `to_u64`:
+
+```rust
+                            let n = n.to_u64().ok_or_else(|| {
+                                anyhow!("Runtime Error: Factorial operand is too large")
+                            })?;
+                            limits::check_predicted_size(
+                                limits::predicted_factorial_bits(n),
+                                limits,
+                            )?;
+                            let res = Self::factorial_helper(n.into());
+```
+
+`power_integer` needs the limits passed in, since it is an associated function. Change its signature to `fn power_integer(base: Number, exponent: BigInt, limits: Limits)`, have `power` take and forward a `limits: Limits` parameter, and update the single call site in `resolve()` to `Self::power(left_value, right_value, limits)?`. Inside `power_integer`, after computing `exponent` as a `BigUint`, predict before computing:
+
+```rust
+        let exponent_magnitude = exponent
+            .to_u64()
+            .ok_or_else(|| anyhow!(INVALID_POWER_ERR))?;
+        limits::check_predicted_size(
+            limits::predicted_power_bits(&base, exponent_magnitude),
+            limits,
+        )?;
+```
+
+Place it after the `is_negative`/`magnitude` computation and before the `match base`. An exponent that does not fit in a `u64` is refused outright: any base of at least one bit raised to it exceeds every budget.
+
+- [ ] **Step 6: Run the tests**
+
+Run: `cargo test`
+Expected: all green. The two "oversized" tests now complete in milliseconds; if either hangs, the guard is not on the path the expression takes — investigate rather than raising the limit.
+
+Run: `cargo clippy --all-targets 2>&1 | grep -c "^warning:"`, then `cargo fmt --check`
+Expected: no growth, clean.
+
+- [ ] **Step 7: Measure the default, do not assert it**
+
+The spec requires the default to come from a timing rather than a guess. Find the slowest expression the default still accepts and time it:
+
+```bash
+cargo build --release
+time (printf '200000!\nquit\n' | ./target/release/yarer -q)
+time (printf '2^1000000\nquit\n' | ./target/release/yarer -q)
+```
+
+`200000!` predicts roughly 3.2 Mibit and is therefore already refused by the 1 Mibit default; walk `n` down until it is accepted, and time that. If the slowest accepted case takes more than a second, lower `max_value_bits` until it does not, then record the final figure, the expression and the timing in the spec under component B, replacing the sentence that says the default is provisional.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A src tests docs
+git commit -m "Refuse results that are too large instead of computing forever
+
+999999999! and 10^100000000 never returned: the only guard on the factorial
+was that its operand fit in a u64, and none at all on exponentiation.
+
+Both are now predicted before being computed - Stirling for the factorial,
+base size times exponent for the power - and the four arithmetic operators
+check the result they produced, so growth through repeated multiplication
+is caught too. The budget is one knob, Limits::max_value_bits, on by
+default and configurable through Session::with_limits."
+```
+
+---
+
+### Task 4: Function arity
+
+Component C of the spec. Closes defect 4, and makes parentheses mandatory after a function name.
+
+**Files:**
+- Modify: `src/token.rs` (`MathFunction::arity`)
+- Modify: `src/rpn_resolver.rs` (`reverse_polish_notation`, plus three new error statics)
+- Test: `tests/integration_tests.rs`, `src/token.rs`
+
+**Interfaces:**
+- Consumes: nothing from Tasks 2 and 3.
+- Produces: `MathFunction::arity(self) -> u8`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `mod tests` in `src/token.rs`:
+
+```rust
+    #[test]
+    fn test_arity_of_the_two_argument_functions() {
+        assert_eq!(MathFunction::Max.arity(), 2);
+        assert_eq!(MathFunction::Min.arity(), 2);
+        assert_eq!(MathFunction::Sin.arity(), 1);
+        assert_eq!(MathFunction::Cdf.arity(), 1);
+    }
+```
+
+Append to `tests/integration_tests.rs`:
+
+```rust
+#[test]
+fn test_wrong_arity_is_diagnosed_by_name() {
+    let session = Session::init();
+    for (expr, expected, given) in [("max(1)", 2, 1), ("max(1,2,3)", 2, 3), ("sin(1,2)", 1, 2)] {
+        let mut resolver = session.process(expr);
+        let err = resolver.resolve().unwrap_err().to_string();
+        assert!(
+            err.contains(&format!("expects {expected}")) && err.contains(&format!("{given} given")),
+            "{expr} reported: {err}"
+        );
+    }
+}
+
+#[test]
+fn test_empty_argument_list_is_diagnosed() {
+    let session = Session::init();
+    let mut resolver = session.process("max()");
+    let err = resolver.resolve().unwrap_err().to_string();
+    assert!(err.contains("0 given"), "message was: {err}");
+}
+
+#[test]
+fn test_comma_outside_a_function_call_is_diagnosed() {
+    let session = Session::init();
+    let mut resolver = session.process("(1,2)");
+    let err = resolver.resolve().unwrap_err().to_string();
+    assert!(err.contains("function call"), "message was: {err}");
+}
+
+#[test]
+fn test_a_function_name_requires_parentheses() {
+    let session = Session::init();
+    for expr in ["sin 5", "sqrt 16", "cos"] {
+        let mut resolver = session.process(expr);
+        let err = resolver.resolve().unwrap_err().to_string();
+        assert!(err.contains("must be followed by"), "{expr} reported: {err}");
+    }
+    // The parenthesised form is untouched.
+    resolve_decimal!("sin(5)", -0.9589242746631385);
+}
+
+#[test]
+fn test_nested_and_multi_argument_calls_still_work() {
+    resolve_natural!("min(max(2,3),max(5,1))", 3);
+    resolve_natural!("max(1+2,3*4)-min(10,5)", 7);
+    resolve_natural!("max(1,(2+3))", 5);
+}
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `cargo test --test integration_tests test_wrong_arity_is_diagnosed_by_name`
+Expected: FAIL — the message is the generic "The mathematical expression is malformed."
+
+Run: `cargo test test_arity_of_the_two_argument_functions`
+Expected: FAIL — `no method named 'arity'`.
+
+- [ ] **Step 3: Declare the arity**
+
+In `src/token.rs`, next to the `MathFunction` enum:
+
+```rust
+impl MathFunction {
+    /// How many arguments this function takes.
+    ///
+    /// [`MathFunction::None`] is unreachable — [`Token::get_some`] never yields
+    /// it — and reports 1 rather than panicking, so that no input can reach a
+    /// panic through this path.
+    #[must_use]
+    pub const fn arity(self) -> u8 {
+        match self {
+            MathFunction::Max | MathFunction::Min => 2,
+            _ => 1,
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Count arguments in the shunting yard**
+
+In `src/rpn_resolver.rs`, add the three error statics beside the existing ones:
+
+```rust
+static COMMA_OUTSIDE_CALL_ERR: &str =
+    "Parse Error: ',' is only valid between the arguments of a function call.";
+static UNBALANCED_BRACKET_ERR: &str = "Parse Error: Unbalanced brackets.";
+```
+
+Add the frame type just above `impl RpnResolver`:
+
+```rust
+/// One entry per open bracket, recording whether that bracket opens a function
+/// call and how many arguments it has seen so far.
+struct BracketFrame {
+    function: Option<MathFunction>,
+    commas: usize,
+    has_content: bool,
+}
+
+impl BracketFrame {
+    /// An empty pair of brackets carries zero arguments; otherwise there is one
+    /// more argument than there are separators.
+    fn argument_count(&self) -> usize {
+        if self.has_content {
+            self.commas + 1
+        } else {
+            0
+        }
+    }
+}
+```
+
+In `reverse_polish_notation`, declare two locals next to `operators_stack`:
+
+```rust
+        let mut bracket_stack: Vec<BracketFrame> = Vec::new();
+        let mut pending_function: Option<MathFunction> = None;
+```
+
+At the very top of the `for t in infix_stack` loop, before the `match`, enforce the parenthesis rule and record that the innermost bracket has content:
+
+```rust
+            if let Some(fun) = pending_function {
+                if !matches!(t, Token::Bracket(token::Bracket::Open)) {
+                    return Err(anyhow!(
+                        "Parse Error: Function '{}' must be followed by '('.",
+                        fun.to_string().to_lowercase()
+                    ));
+                }
+            }
+
+            if !matches!(t, Token::Comma | Token::Bracket(token::Bracket::Close)) {
+                if let Some(frame) = bracket_stack.last_mut() {
+                    frame.has_content = true;
+                }
+            }
+```
+
+Then extend four arms of the existing `match`:
+
+`Token::Function(f)` — record it as pending in addition to pushing it:
+
+```rust
+                Token::Function(f) => {
+                    pending_function = Some(f);
+                    operators_stack.push(t.clone());
+                }
+```
+
+`Token::Bracket(Open)` — open a frame, consuming any pending function:
+
+```rust
+                Token::Bracket(token::Bracket::Open) => {
+                    bracket_stack.push(BracketFrame {
+                        function: pending_function.take(),
+                        commas: 0,
+                        has_content: false,
+                    });
+                    operators_stack.push(t.clone());
+                }
+```
+
+`Token::Bracket(Close)` — close the frame and check, before the existing operator-popping loop:
+
+```rust
+                Token::Bracket(token::Bracket::Close) => {
+                    let frame = bracket_stack.pop().ok_or_else(|| anyhow!(UNBALANCED_BRACKET_ERR))?;
+                    if let Some(fun) = frame.function {
+                        let given = frame.argument_count();
+                        let expected = usize::from(fun.arity());
+                        if given != expected {
+                            return Err(anyhow!(
+                                "Parse Error: Function '{}' expects {} argument(s), {} given.",
+                                fun.to_string().to_lowercase(),
+                                expected,
+                                given
+                            ));
+                        }
+                    }
+                    // ... the existing body, unchanged, follows here ...
+                }
+```
+
+`Token::Comma` — attribute the separator to the enclosing call, before the existing operator-flushing loop:
+
+```rust
+                Token::Comma => {
+                    let frame = bracket_stack
+                        .last_mut()
+                        .ok_or_else(|| anyhow!(COMMA_OUTSIDE_CALL_ERR))?;
+                    if frame.function.is_none() {
+                        return Err(anyhow!(COMMA_OUTSIDE_CALL_ERR));
+                    }
+                    frame.commas += 1;
+                    // ... the existing body, unchanged, follows here ...
+                }
+```
+
+After the loop, an expression that ends on a function name is rejected:
+
+```rust
+        if let Some(fun) = pending_function {
+            return Err(anyhow!(
+                "Parse Error: Function '{}' must be followed by '('.",
+                fun.to_string().to_lowercase()
+            ));
+        }
+```
+
+`MathFunction` needs to be in scope in `rpn_resolver.rs`; it already is, through the existing `use crate::token::{self, MathFunction, Number, Operator, Token};`.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `cargo test`
+Expected: all green.
+
+Two existing tests need attention if they fail, and both are legitimate consequences to accept rather than bugs to work around:
+- anything asserting a bare `sin 5` form — there is none at the time of writing, confirmed by grep
+- `test_invalid_input_is_rejected` may already cover `(1,2)`; if it asserts the old generic message, update it to the new specific one
+
+Run: `cargo clippy --all-targets 2>&1 | grep -c "^warning:"`, then `cargo fmt --check`
+
+- [ ] **Step 6: Update the documentation for the parenthesis rule**
+
+`README.md` and the module docs in `src/lib.rs` both list the built-in functions. Add one sentence after that list in each:
+
+```
+Function arguments are always parenthesised: `sqrt(16)`, `max(1,2)`.
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A src tests README.md
+git commit -m "Validate function arity while building the RPN form
+
+max(1), max(1,2,3), sin(1,2) and max() all reported the same generic
+'malformed expression'. The shunting yard now keeps one frame per open
+bracket, recording whether it opens a call and how many arguments it has
+seen, and reports the function by name with the counts it expected and
+received. A comma outside a call is diagnosed on its own terms.
+
+Parentheses after a function name become mandatory: 'sin 5' used to work
+by accident, and argument counting has no meaning without a bracket to
+count within."
+```
+
+---
+
+## Definition of done for the stage
+
+- [ ] `cargo test` green, with the new tests from all four tasks.
+- [ ] `test_chained_assignment_sets_all_variables` (`x=y=5` sets both and returns 5) and `test_chained_expressions` (`x=2; y=3; x*y` returns 6) still pass untouched. The spec names them because they are load-bearing behaviour that none of these four changes may disturb.
+- [ ] `cargo clippy --all-targets` at or below 40 warnings, with `too many lines` gone.
+- [ ] `cargo fmt --check` clean.
+- [ ] The measured `max_value_bits` figure and its timing recorded in the spec.
+- [ ] The three declared behaviour changes gathered for the 0.3.0 CHANGELOG: integral results now come back as `NaturalNumber`, oversized results are refused, parentheses after a function name are mandatory.

--- a/docs/superpowers/plans/2026-08-04-reliable-core.md
+++ b/docs/superpowers/plans/2026-08-04-reliable-core.md
@@ -615,13 +615,33 @@ fn test_the_limit_is_configurable() {
 
 #[test]
 fn test_growth_through_multiplication_is_caught() {
-    // 2^3000 occupies 3001 bits and is admitted; squaring it needs 6001, which
-    // is not. Each step is individually under budget only until it is not.
-    let session = Session::with_limits(Limits { max_value_bits: 4096 });
-    let mut resolver = session.process("x=2^3000; x*x");
-    assert!(resolver.resolve().is_err(), "the product needs 6001 bits");
+    // Budget 4000 is exactly the power's own prediction for this base and
+    // exponent (size_in_bits(2) * 2000 = 2 * 2000 = 4000): the largest value the
+    // predictive power check admits for "2^2000", so a failure here can only come
+    // from the multiplication, not from the power check firing again. 2^2000 is
+    // actually 2001 bits (passes both checks); squaring it needs 4001 bits, over
+    // budget, and only the post-hoc Mul check can catch that.
+    let session = Session::with_limits(Limits {
+        max_value_bits: 4000,
+    });
+    let mut resolver = session.process("x=2^2000; x*x");
+    let err = resolver.resolve().unwrap_err().to_string();
+    // "occupies" is the post-hoc wording; a prediction says "would need".
+    assert!(err.contains("occupies"), "message was: {err}");
 }
 ```
+
+**Amended after Task 3's fix rounds.** This test originally specified
+`Limits { max_value_bits: 4096 }` with `x=2^3000; x*x`, and a comment saying the
+product's 6001 bits are what fails. They are not. The power prediction for `2^3000`
+is `bits(2) · 3000 = 6000`, already over 4096, so the expression is refused before
+`x*x` is ever reached and the post-hoc `Mul` check — the only thing this test exists
+to cover — never runs. Verified: the original wording errors with `the result would
+need about 6000 bits`, the predictive wording, while the version above errors with
+`the result occupies about 4001 bits`. The budget is now set to exactly the power
+prediction so that the power check must pass, and the assertion is on the `"occupies"`
+wording so that a regression to the predictive path fails the test instead of
+silently satisfying it.
 
 Add `use yarer::limits::Limits;` to the imports at the top of the file.
 
@@ -691,15 +711,26 @@ pub fn check_predicted_size(predicted_bits: u128, limits: Limits) -> anyhow::Res
     Ok(())
 }
 
-/// Predicts the bit length of `n!` without computing it, via Stirling:
-/// `log2(n!) ≈ n·log2(n) − 1.44·n`.
+/// Predicts the bit length of `n!` without computing it, via Stirling's series:
+/// `log2(n!) ≈ n·log2(n) − n·log2(e) + 0.5·log2(2πn)`.
+///
+/// The first two terms alone are optimistic — they omit the `0.5·log2(2πn)` term,
+/// which for `n` in the hundreds of thousands is close to ten bits, enough to let a
+/// prediction land just under a tight budget while the true value lands just over it.
 #[must_use]
+#[allow(clippy::cast_precision_loss)]
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 pub fn predicted_factorial_bits(n: u64) -> u128 {
     if n < 2 {
         return 1;
     }
     let n_f = n as f64;
-    let bits = n_f.mul_add(n_f.log2(), -1.442_695_040_888_963_4 * n_f);
+    // -1.442_695_040_888_963_4 is bit-for-bit -LOG2_E; clippy's approx_constant
+    // lint (deny-by-default) requires the named constant instead of the literal.
+    let leading_terms = n_f.mul_add(n_f.log2(), -std::f64::consts::LOG2_E * n_f);
+    // 0.5 * log2(2 * pi * n); TAU is the named constant for 2*pi.
+    let correction = 0.5 * (std::f64::consts::TAU * n_f).log2();
+    let bits = leading_terms + correction;
     // Round up and never report less than one bit.
     bits.max(1.0).ceil() as u128
 }
@@ -729,13 +760,13 @@ mod tests {
     }
 
     #[test]
-    fn test_factorial_prediction_is_in_the_right_ballpark() {
-        // 1000! is 8529 bits; Stirling must land close and never far under.
-        let predicted = predicted_factorial_bits(1000);
-        assert!(
-            (8000..=9200).contains(&predicted),
-            "predicted {predicted} bits for 1000!"
-        );
+    fn test_factorial_prediction_matches_stirling_with_correction() {
+        // 1000! is 8529 bits (lgamma(1001)/ln(2) = 8529.4); the three-term series
+        // used here predicts 8530. A wide "ballpark" range does not pin this down:
+        // dropping the 0.5*log2(2*pi*n) correction term still predicts 8524, which
+        // is inside almost any range wide enough to be useful, so only an exact
+        // value catches the correction term going missing.
+        assert_eq!(predicted_factorial_bits(1000), 8530);
     }
 
     #[test]
@@ -752,6 +783,30 @@ mod tests {
     }
 }
 ```
+
+**`predicted_factorial_bits` amended after Task 3's fix rounds.** It originally
+specified the two-term Stirling series, `n·log2(n) − n·log2(e)`, with a doc comment to
+match, and wrote the constant as the literal `1.442_695_040_888_963_4`. Two problems.
+That literal is bit-for-bit `std::f64::consts::LOG2_E`, which trips clippy's
+deny-by-default `approx_constant`, so the snippet as written does not compile under
+this crate's lint settings. And two terms is not enough: the omitted `0.5·log2(2πn)`
+correction is close to ten bits at the scale the default budget operates at, which is
+exactly how the first calibration pass admitted a `71422!` whose real size was eight
+bits over its own nominal budget. The design spec in this same change requires the
+three-term series and explains why at length; this snippet now matches it.
+
+The companion test was tightened at the same time, from
+`assert!((8000..=9200).contains(&predicted))` to `assert_eq!(…, 8530)`. The loose range
+is why the two-term formula survived review: dropping the correction term still predicts
+8524 for `1000!`, comfortably inside that range, so the test could not distinguish the
+two formulas it was meant to be checking.
+
+One further inconsistency is left standing knowingly: `predicted_power_bits`' doc above
+still calls itself "an upper bound on the bit length of `base^exponent`", which the
+merged implementation no longer claims, because a negative exponent returns a reciprocal
+whose denominator is also counted. That was corrected in `src/limits.rs` rather than
+here, and the surrounding snippet is a Task 3 artefact; the authority on what the
+function guarantees is the source, not this plan.
 
 - [ ] **Step 4: Thread the limits through `Session` and `RpnResolver`**
 

--- a/docs/superpowers/plans/2026-08-04-reliable-core.md
+++ b/docs/superpowers/plans/2026-08-04-reliable-core.md
@@ -735,12 +735,18 @@ pub fn predicted_factorial_bits(n: u64) -> u128 {
     bits.max(1.0).ceil() as u128
 }
 
-/// An upper bound on the bit length of `base^exponent` for an integral exponent.
+/// An estimate of the bit length of `base` raised to the *magnitude* of an integral
+/// exponent.
 ///
-/// It uses `bits(base)` where `log2(base)` would be exact, so it overestimates by
+/// Note the "magnitude": a negative exponent returns the reciprocal, and
+/// `size_in_bits` counts a rational's denominator as well as its numerator, so this
+/// is **not** an upper bound on what the caller ends up holding. `2^-1` estimates
+/// 2 bits and produces `1/2`, which measures `1 + 2 = 3`.
+///
+/// It also uses `bits(base)` where `log2(base)` would be exact, so it overestimates by
 /// up to a factor of two for small bases — `2^100` is predicted at 200 bits and
-/// occupies 101. A guard that errs toward refusing is the right direction to err in,
-/// and the discrepancy only matters within a factor of two of the budget.
+/// occupies 101. For a pre-filter, erring toward refusing is the right direction to
+/// err in; `check_size` on the finished value is what makes the budget exact.
 #[must_use]
 pub fn predicted_power_bits(base: &Number, exponent_magnitude: u64) -> u128 {
     let base_bits = size_in_bits(base).max(1);
@@ -801,12 +807,15 @@ is why the two-term formula survived review: dropping the correction term still 
 8524 for `1000!`, comfortably inside that range, so the test could not distinguish the
 two formulas it was meant to be checking.
 
-One further inconsistency is left standing knowingly: `predicted_power_bits`' doc above
-still calls itself "an upper bound on the bit length of `base^exponent`", which the
-merged implementation no longer claims, because a negative exponent returns a reciprocal
-whose denominator is also counted. That was corrected in `src/limits.rs` rather than
-here, and the surrounding snippet is a Task 3 artefact; the authority on what the
-function guarantees is the source, not this plan.
+**`predicted_power_bits`' doc amended for the same reason.** It opened "An upper bound on
+the bit length of `base^exponent`", which is false for a negative exponent: the value
+returned is the reciprocal, and `size_in_bits` counts a rational's denominator as well as
+its numerator, so `2^-1` estimates 2 bits and produces `1/2`, which measures 3. That was
+found after the branch had merged its own copy, and the plan is corrected here to match.
+The wider point the three amendments share is recorded in the design spec: a prediction is
+a pre-filter that buys the right to refuse a hopeless computation cheaply, and
+`check_size` on the finished value is what makes the budget exact. Snippets that describe
+a prediction as a bound are describing the wrong contract.
 
 - [ ] **Step 4: Thread the limits through `Session` and `RpnResolver`**
 

--- a/docs/superpowers/specs/2026-08-04-reliable-core-design.md
+++ b/docs/superpowers/specs/2026-08-04-reliable-core-design.md
@@ -114,6 +114,22 @@ no existing signature changes.
 Limits are **on by default**. An opt-in limit leaves the default configuration
 non-terminating, which is precisely the state this stage exists to remove.
 
+**The 1 Mibit default is provisional and must be chosen from a measurement.** A bit
+budget bounds memory directly and running time only indirectly: `n!` is not one
+multiplication but a loop of `n` bignum multiplications, so cost grows faster than the
+size of the result. A limit calibrated on memory alone can still admit a computation
+taking several seconds, which inside a service is the same availability problem in a
+quieter form. Before the stage is done, the worst case at the limit — the slowest
+expression that the limit still accepts — is timed, and the default is lowered until
+that worst case stays comfortably below one second on ordinary hardware. The measured
+figure and the expression used to obtain it are recorded here.
+
+One consequence to accept knowingly: for `+ − × ÷` the check happens after the fact,
+so an operation whose operands are each just under the limit allocates the oversized
+result before it is rejected. The overshoot is bounded by roughly a factor of two and
+is transient. Avoiding it would mean predicting the size of every arithmetic result,
+which buys little for the complexity it costs.
+
 ### C. Function arity — closes defect 4
 
 `MathFunction` gains `arity(self) -> u8`: 2 for `Max` and `Min`, 1 for the rest.
@@ -199,4 +215,5 @@ Test-driven: for each defect the failing test is written first.
 - `cargo clippy --all-targets` below the current 40 warnings, with
   `too many lines` gone.
 - `cargo fmt --check` clean.
+- The default `max_value_bits` justified by a recorded timing, not asserted.
 - Every declared behaviour change recorded for the 0.3.0 CHANGELOG entry.

--- a/docs/superpowers/specs/2026-08-04-reliable-core-design.md
+++ b/docs/superpowers/specs/2026-08-04-reliable-core-design.md
@@ -133,31 +133,37 @@ calibrated on memory alone can still admit a computation taking several seconds,
 inside a service is the same availability problem in a quieter form. `power_integer`
 uses repeated squaring — `O(log exponent)` multiplications — so for a fixed bit budget
 the factorial is the more expensive of the two predictive checks; it dominates the
-worst case. Walking `n` down from `200000!` (refused, ~3.2 Mibit) against a release
-build (`cargo build --release`) found the boundary the 1 Mibit default admits: `71422!`
-succeeds (predicted 1_048_574 bits), while `71423!` is refused (predicted 1_048_591
-bits). Timing the admitted boundary case,
-```
-time (printf '71422!\nquit\n' | ./target/release/yarer -q)
-```
-took ~0.53–0.56s across three runs, comfortably below one second on ordinary hardware.
-For comparison, the boundary power case, `2^524288` (the largest exponent whose
-predicted 1_048_576 bits still fits), took ~0.05s — confirming the factorial, not the
-power, sets the worst case. Since the worst case the default admits already stays well
-under the one-second budget, `max_value_bits` keeps its `1 << 20` value; no lowering
-was needed.
+worst case.
 
-One imprecision surfaced by this measurement and worth recording rather than hiding:
-`71422!`'s *actual* bit length, computed independently, is 1_048_584 — 8 bits over the
-nominal budget, and above the 1_048_574 the guard predicted. The simplified Stirling
-form used here (`n·log2 n − n·log2 e`) omits the `+0.5·log2(2πn)` correction term, so it
-slightly underestimates for every `n`; the gap is a few bits and grows only as `log n`,
-invisible except within a handful of bits of the boundary, which is exactly where this
-measurement landed. Unlike the power check — documented above to overestimate, and so
-err toward refusing — the factorial check is not guaranteed conservative in the same
-direction. The practical exposure is a fixed, tiny number of bits, not a scaling one,
-so it does not change the timing conclusion above; it is noted here as a known gap
-rather than silently glossed over.
+The factorial prediction uses the full Stirling series, `n·log2(n) − n·log2(e) +
+0.5·log2(2πn)`, not just its two leading terms: the omitted correction term is close to
+ten bits at the scale this measurement operates at, enough to let a two-term prediction
+admit a value whose actual size is over budget (an earlier pass of this measurement
+caught exactly that — see the note below). With the correction included, the prediction
+matches `lgamma(n+1)/ln(2)` to under a bit, so — like the power prediction, which
+overestimates for the opposite reason — the factorial prediction no longer
+underestimates the size it guards.
+
+Walking `n` down from `200000!` (refused, ~3.2 Mibit) against a release build (`cargo
+build --release`) found the boundary the 1 Mibit default admits: `71421!` succeeds
+(predicted 1_048_568 bits, matching its actual bit length exactly), while `71422!` is
+refused (predicted 1_048_584 bits, likewise exact). Timing the admitted boundary case,
+```
+time (printf '71421!\nquit\n' | ./target/release/yarer -q)
+```
+took ~0.43s across three runs, comfortably below one second on ordinary hardware. For
+comparison, the boundary power case, `2^524288` (the largest exponent whose predicted
+1_048_576 bits still fits), took ~0.05s — confirming the factorial, not the power, sets
+the worst case. Since the worst case the default admits already stays well under the
+one-second budget, `max_value_bits` keeps its `1 << 20` value; no lowering was needed.
+
+**Note on the correction term's origin.** The first pass of this measurement used only
+the two leading Stirling terms and found the boundary at `71422!` — but that build's
+prediction for `71422!` (1_048_574 bits) undershot the value's actual bit length
+(1_048_584, verified independently), meaning the guard admitted a computation 8 bits
+over its own nominal budget. The gap matched the omitted `0.5·log2(2πn)` term almost
+exactly, which is why that term is now included above rather than left as a documented
+caveat.
 
 One consequence to accept knowingly: for `+ − × ÷` the check happens after the fact,
 so an operation whose operands are each just under the limit allocates the oversized

--- a/docs/superpowers/specs/2026-08-04-reliable-core-design.md
+++ b/docs/superpowers/specs/2026-08-04-reliable-core-design.md
@@ -247,8 +247,9 @@ evaluation is now bounded by `Limits::max_value_bits`, 1 Mibit by default, rough
 315,000 decimal digits. Expressions such as `999999999!` or `10^100000000` return an
 error immediately instead of running until they exhaust memory; where the size can be
 predicted, the refusal happens before any of the work is done. The bound is
-configurable per session through `Session::with_limits`, and it applies to every
-literal, every variable read and every arithmetic result.
+configurable per session through `Session::with_limits`, and it applies to every value
+on the evaluation stack, whatever produced it — literals, variables, arithmetic results
+and function results alike.
 
 **A function name must be followed by `(`.** `sin 5` and `sqrt 16` were previously
 accepted and evaluated as `sin(5)` and `sqrt(16)`; they are now parse errors that name

--- a/docs/superpowers/specs/2026-08-04-reliable-core-design.md
+++ b/docs/superpowers/specs/2026-08-04-reliable-core-design.md
@@ -1,0 +1,202 @@
+# Design — Stage 1: A Reliable Core
+
+Date: 2026-08-04
+Status: approved, not yet implemented
+Target release: part of 0.3.0 (published after Stage 2; Stage 1 does not ship on its own)
+
+## Context
+
+Yarer 0.2.0 is published on crates.io and is therefore used as a library, not only
+as a REPL. The goal for the next development cycle is to make it *production ready*:
+something an embedder can rely on. Breaking changes are acceptable — the crate is
+pre-1.0 and semver permits them — provided they are declared.
+
+"Production ready" spans three subsystems with a one-way dependency between them,
+so the work is split into three stages, each with its own spec, plan and merge:
+
+1. **Reliable core** (this document) — correctness, guaranteed termination, argument validation.
+2. **Public API** — typed errors replacing `anyhow::Error`, error positions, `Send`/`Sync` session.
+3. **Surface** — script mode for the binary, clippy in CI, MSRV, CHANGELOG, fuzzing.
+
+The order matters: typing the error enum before deciding which error conditions exist
+means writing that enum twice. The size limits introduced in Stage 1 create an error
+condition that does not exist today.
+
+## Problems in scope
+
+Every item below was reproduced against the 0.2.0 binary before being written down.
+
+| # | Defect | Evidence |
+|---|--------|----------|
+| 1 | `abs(-3)!`, `floor(2.5)!` and `max(3,2)!` all fail | "Factorial is only defined for non-negative integers" |
+| 2 | `Number` violates the `PartialEq`/`PartialOrd` contract | `NaturalNumber(2) == DecimalNumber(2/1)` is `false`, `>=` is `true` |
+| 3 | `999999999!` and `10^100000000` never terminate | both hit a 5-second timeout (exit 124); the second also exhausts memory |
+| 4 | Function arity is never validated | `max(1,2,3)` reports the generic "malformed expression" |
+
+Defects 1 and 2 share a single root cause: the same mathematical value has two
+representations (`NaturalNumber(2)` and `DecimalNumber(2/1)`), and the code branches
+on the enum tag instead of the value.
+
+## Explicitly out of scope
+
+- **Undefined variables keep evaluating to 0.** `y+1` returns `1` with no warning.
+  This is a deliberate decision by the maintainer: it matches `bc`, and changing it
+  would require distinguishing an assignment target from a value read, since `x=5`
+  reads `x` before assigning it.
+- **Prefix factorial stays accepted.** `!5` returns `120` because `mod_unary_operators`
+  (`parser.rs:56`) treats `Fac` as an operand-seen token. It produces no wrong result
+  and no hang — it only accepts a spelling nobody writes. Tightening the grammar needs
+  a sequence-validation pass, which is designed far better alongside error positions in
+  Stage 2. Doing it now means writing that pass twice.
+- Typed errors, error positions, `Send`/`Sync`, script mode, clippy in CI, MSRV,
+  CHANGELOG, fuzzing — Stages 2 and 3.
+- New mathematical capability (`%`, scientific notation, hyperbolic functions,
+  user-defined functions). Those are features, not reliability, and deserve their own
+  decision.
+
+## Components
+
+### A. Canonical `Number` — closes defects 1 and 2
+
+**Invariant: `DecimalNumber` implies a denominator different from 1.** An integral
+value has exactly one representation, `NaturalNumber`.
+
+- A single internal constructor `Number::decimal(BigRational) -> Number` degrades to
+  `NaturalNumber` when `denom == 1`, and becomes the only internal way to build a decimal.
+- `to_decimal_number()` (`rpn_resolver.rs:512`) is deleted. It is the function that
+  *creates* defect 1, forcing the `Decimal` tag onto integral results of `abs`, `floor`,
+  `ceil`, `round`, `max` and `min`, which factorial then rejects.
+- Factorial stops inspecting the tag and inspects the value, through a new
+  `Number::as_integer(&self) -> Option<BigInt>` returning `Some` for a `NaturalNumber`
+  and for a rational whose denominator is 1. That logic already exists as
+  `integer_exponent()` (`rpn_resolver.rs:519`), written for exponentiation: it becomes
+  one method used by both call sites rather than a second copy.
+- `PartialEq` changes from derived to hand-written and value-based, consistent with the
+  existing hand-written `PartialOrd`.
+
+The last two points are redundant by construction — with the invariant in force the two
+representations never coexist. Both are done anyway because `Number` is a **public enum**:
+any consumer can construct `Number::DecimalNumber(BigRational::from_integer(2.into()))`
+by hand. The invariant protects our code, value-based `PartialEq` protects us from theirs.
+
+A welcome side effect: the tests in `session.rs` that assert `DecimalNumber(-5.0)` keep
+passing once the result becomes `NaturalNumber(-5)`, because equality is by value. This
+must be confirmed by running them, not assumed.
+
+### B. Size limits — closes defect 3
+
+The principle is to **predict the size of the result and refuse before computing it**,
+rather than computing under a timeout. No threads, no interruption: a deterministic,
+testable, instantaneous decision.
+
+- **`n!`** — the bit length of `n!` is estimable without computing it
+  (`≈ n·log₂n − 1.44·n`). `999999999!` exceeds any sensible threshold and is refused
+  immediately; `1000!` occupies 8530 bits and passes.
+- **`base^exp` with integral `exp`** — the result needs `size(base) × |exp|` bits, known
+  exactly and immediately. `10^100000000` asks for ~4·10⁸ bits and is refused; `2^1000`
+  passes. A negative exponent is measured on its magnitude: the reciprocal of a huge
+  integer is an equally huge rational.
+- **`+ − × ÷`** — the result already exists, so it is checked after the fact
+  (`bits()` is cheap). This is required because a chain such as
+  `x=10^1000; x=x*x; x=x*x` grows through multiplications that are individually
+  under the threshold.
+
+Throughout, `size(n)` means `bits()` for a `NaturalNumber` and
+`numer().bits() + denom().bits()` for a `DecimalNumber`. It is one function, used by
+every check.
+
+One knob: `Limits { max_value_bits: u64 }`, default 1 Mibit (1_048_576 bits,
+roughly 315_000 decimal digits) — generous for any legitimate use. It lives on the
+`Session`, reached through `Session::with_limits(limits: Limits) -> Session`;
+`Session::init()` delegates to it with `Limits::default()`. This is a pure addition:
+no existing signature changes.
+
+Limits are **on by default**. An opt-in limit leaves the default configuration
+non-terminating, which is precisely the state this stage exists to remove.
+
+### C. Function arity — closes defect 4
+
+`MathFunction` gains `arity(self) -> u8`: 2 for `Max` and `Min`, 1 for the rest.
+
+The `MathFunction::None` variant is unreachable — `Token::get_some` never yields it, and
+`resolve()` already answers it with "This should never happen!". `arity()` reports 1 for
+it rather than panicking, so that no input can reach a panic through this path. Removing
+the variant outright is a public-API change and belongs to the Stage 2 API pass.
+
+The shunting yard keeps an **argument-count stack** alongside the operator stack, with
+one entry per open bracket recording whether that bracket opens a function call and how
+many arguments it has seen. Each `,` increments the top entry; on the closing bracket the
+count is compared against the declared arity. A `,` whose enclosing bracket is not a
+function call becomes its own diagnosable error instead of the generic "malformed".
+
+The check happens while building the RPN form, not while evaluating it: it does not
+depend on runtime values, so `max(1,2,3)` is wrong always, not "wrong once you reach it".
+
+**Declared behaviour change beyond the four defects.** Today `sin 5` works and equals
+`sin(5)`: parentheses are optional. That is not a design decision but an accident of the
+algorithm — the function sits on the operator stack and is emitted at the end regardless.
+Argument counting has no defined meaning without a bracket to count within, so
+**parentheses after a function name become mandatory**, as documented in every calculator
+and as `bc` requires. Neither the tests nor the README use the bare form, so migration
+cost is nil, but it is observable and belongs in the CHANGELOG.
+
+### D. Extracting function evaluation
+
+`resolve()` is 243 lines (clippy: `this function has too many lines (243/100)`), and
+component B adds checks at three separate points inside it. The `match fun { … }` block
+spanning `rpn_resolver.rs:194`–`:296` moves into a dedicated unit with a clear boundary:
+it takes the function and the operand stack and returns `Result<Number>`.
+
+This is not gratuitous refactoring — it is the code the other components modify, and
+leaving it in place would mean shipping a 280-line function.
+
+## Errors
+
+Error values remain `anyhow` strings in this stage; typing them is Stage 2. The four new
+conditions are nevertheless introduced as **distinct, specific messages**, never as another
+reuse of `MALFORMED_ERR`:
+
+- size limit exceeded — names the limit and the requested size
+- wrong arity — names the function, the expected count and the given count
+- comma outside a function call
+- function name not followed by `(`
+
+The reason is practical: Stage 2 turns conditions into enum variants, and every condition
+that collapses into the generic string today is a variant to excavate tomorrow.
+
+## Work order
+
+`D → A → B → C`, deliberately:
+
+1. **D** is a pure move with unchanged behaviour, so it goes first, with the existing
+   64 tests green on both sides of it as the evidence.
+2. **A** changes the type the other two components consume, so it precedes them.
+3. **B**, then **C** — independent of each other.
+
+Behaviour changes then land in an already-clean structure and each commit has a
+readable diff.
+
+## Testing
+
+Test-driven: for each defect the failing test is written first.
+
+- `abs(-3)!`, `floor(2.5)!`, `max(3,2)!` return the correct factorial.
+- A table of pairs asserting `a == b` if and only if `a.partial_cmp(&b) == Some(Equal)`,
+  across both variants.
+- `999999999!` and `10^100000000` return `Err`. These tests are self-diagnosing: they must
+  complete instantly, so a broken limit hangs the suite visibly rather than passing quietly.
+- A `Session` built with a deliberately small `max_value_bits` refuses an expression that
+  the default limit accepts, proving the knob is wired through.
+- `max(1)`, `max(1,2,3)`, `sin(1,2)`, `max()` each produce their specific message.
+- `sin 5` is rejected; `sin(5)` is unchanged.
+- `x=y=5` still assigns both variables and returns 5, and `x=2; y=3; x*y` still returns 6
+  (chained assignment and chained expressions are load-bearing existing behaviour).
+- The 64 existing tests stay green except where this document declares otherwise.
+
+## Definition of done
+
+- `cargo test` green.
+- `cargo clippy --all-targets` below the current 40 warnings, with
+  `too many lines` gone.
+- `cargo fmt --check` clean.
+- Every declared behaviour change recorded for the 0.3.0 CHANGELOG entry.

--- a/docs/superpowers/specs/2026-08-04-reliable-core-design.md
+++ b/docs/superpowers/specs/2026-08-04-reliable-core-design.md
@@ -126,15 +126,38 @@ no existing signature changes.
 Limits are **on by default**. An opt-in limit leaves the default configuration
 non-terminating, which is precisely the state this stage exists to remove.
 
-**The 1 Mibit default is provisional and must be chosen from a measurement.** A bit
-budget bounds memory directly and running time only indirectly: `n!` is not one
-multiplication but a loop of `n` bignum multiplications, so cost grows faster than the
-size of the result. A limit calibrated on memory alone can still admit a computation
-taking several seconds, which inside a service is the same availability problem in a
-quieter form. Before the stage is done, the worst case at the limit — the slowest
-expression that the limit still accepts — is timed, and the default is lowered until
-that worst case stays comfortably below one second on ordinary hardware. The measured
-figure and the expression used to obtain it are recorded here.
+**The 1 Mibit default was measured, not guessed.** A bit budget bounds memory directly
+and running time only indirectly: `n!` is not one multiplication but a loop of `n`
+bignum multiplications, so cost grows faster than the size of the result. A limit
+calibrated on memory alone can still admit a computation taking several seconds, which
+inside a service is the same availability problem in a quieter form. `power_integer`
+uses repeated squaring — `O(log exponent)` multiplications — so for a fixed bit budget
+the factorial is the more expensive of the two predictive checks; it dominates the
+worst case. Walking `n` down from `200000!` (refused, ~3.2 Mibit) against a release
+build (`cargo build --release`) found the boundary the 1 Mibit default admits: `71422!`
+succeeds (predicted 1_048_574 bits), while `71423!` is refused (predicted 1_048_591
+bits). Timing the admitted boundary case,
+```
+time (printf '71422!\nquit\n' | ./target/release/yarer -q)
+```
+took ~0.53–0.56s across three runs, comfortably below one second on ordinary hardware.
+For comparison, the boundary power case, `2^524288` (the largest exponent whose
+predicted 1_048_576 bits still fits), took ~0.05s — confirming the factorial, not the
+power, sets the worst case. Since the worst case the default admits already stays well
+under the one-second budget, `max_value_bits` keeps its `1 << 20` value; no lowering
+was needed.
+
+One imprecision surfaced by this measurement and worth recording rather than hiding:
+`71422!`'s *actual* bit length, computed independently, is 1_048_584 — 8 bits over the
+nominal budget, and above the 1_048_574 the guard predicted. The simplified Stirling
+form used here (`n·log2 n − n·log2 e`) omits the `+0.5·log2(2πn)` correction term, so it
+slightly underestimates for every `n`; the gap is a few bits and grows only as `log n`,
+invisible except within a handful of bits of the boundary, which is exactly where this
+measurement landed. Unlike the power check — documented above to overestimate, and so
+err toward refusing — the factorial check is not guaranteed conservative in the same
+direction. The practical exposure is a fixed, tiny number of bits, not a scaling one,
+so it does not change the timing conclusion above; it is noted here as a known gap
+rather than silently glossed over.
 
 One consequence to accept knowingly: for `+ − × ÷` the check happens after the fact,
 so an operation whose operands are each just under the limit allocates the oversized

--- a/docs/superpowers/specs/2026-08-04-reliable-core-design.md
+++ b/docs/superpowers/specs/2026-08-04-reliable-core-design.md
@@ -247,8 +247,8 @@ evaluation is now bounded by `Limits::max_value_bits`, 1 Mibit by default, rough
 315,000 decimal digits. Expressions such as `999999999!` or `10^100000000` return an
 error immediately instead of running until they exhaust memory; where the size can be
 predicted, the refusal happens before any of the work is done. The bound is
-configurable per session through `Session::with_limits`, and it applies to every value
-on the evaluation stack, literals included.
+configurable per session through `Session::with_limits`, and it applies to every
+literal, every variable read and every arithmetic result.
 
 **A function name must be followed by `(`.** `sin 5` and `sqrt 16` were previously
 accepted and evaluated as `sin(5)` and `sqrt(16)`; they are now parse errors that name

--- a/docs/superpowers/specs/2026-08-04-reliable-core-design.md
+++ b/docs/superpowers/specs/2026-08-04-reliable-core-design.md
@@ -140,9 +140,15 @@ The factorial prediction uses the full Stirling series, `n·log2(n) − n·log2(
 ten bits at the scale this measurement operates at, enough to let a two-term prediction
 admit a value whose actual size is over budget (an earlier pass of this measurement
 caught exactly that — see the note below). With the correction included, the prediction
-matches `lgamma(n+1)/ln(2)` to under a bit, so — like the power prediction, which
-overestimates for the opposite reason — the factorial prediction no longer
-underestimates the size it guards.
+matches `lgamma(n+1)/ln(2)` to within about a bit — a large improvement, but not an
+exact lower bound. The series is still asymptotic, and rounding the estimate up with
+`.ceil()` can still land one bit under the true bit count when the raw estimate falls
+just below an integer: at `n = 2` the estimate is `0.94`, which ceils to `1`, while `2!`
+needs `2` bits. So the remaining exposure is about a bit, not zero — closer to the power
+prediction's behaviour than exact, but not identical to it, since the power prediction's
+one-directional overestimate is structural (it substitutes `bits(base)` for the exact
+`log2(base)`) while this remaining gap is a residual of the asymptotic series and the
+rounding around it.
 
 Walking `n` down from `200000!` (refused, ~3.2 Mibit) against a release build (`cargo
 build --release`) found the boundary the 1 Mibit default admits: `71421!` succeeds

--- a/docs/superpowers/specs/2026-08-04-reliable-core-design.md
+++ b/docs/superpowers/specs/2026-08-04-reliable-core-design.md
@@ -224,8 +224,14 @@ Test-driven: for each defect the failing test is written first.
 ## Definition of done
 
 - `cargo test` green.
-- `cargo clippy --all-targets` below the current 40 warnings, with
-  `too many lines` gone.
+- `cargo clippy --all-targets` at or below the current 40 warnings.
+
+  Not "with `too many lines` gone", which was the original wording and was
+  unattainable: splitting a 243-line function into 141 + 102 leaves both over
+  clippy's 100-line threshold, and the later components add lines to each. Component D
+  buys the module boundary and a 40% reduction, not silence from that lint. Check the
+  count per category, too — a stable total can hide one regression offsetting one
+  improvement, which is exactly what happened when component D landed.
 - `cargo fmt --check` clean.
 - The default `max_value_bits` justified by a recorded timing, not asserted.
 - Every declared behaviour change recorded for the 0.3.0 CHANGELOG entry.

--- a/docs/superpowers/specs/2026-08-04-reliable-core-design.md
+++ b/docs/superpowers/specs/2026-08-04-reliable-core-design.md
@@ -227,6 +227,35 @@ reuse of `MALFORMED_ERR`:
 The reason is practical: Stage 2 turns conditions into enum variants, and every condition
 that collapses into the generic string today is a variant to excavate tomorrow.
 
+## Declared behaviour changes for 0.3.0
+
+The three changes this stage makes to observable behaviour, gathered in one place so
+a release note can be written from them. There is deliberately no `CHANGELOG.md` yet —
+that is Stage 3 — so they live here in the meantime, phrased to be lifted verbatim.
+
+**Integral results are now returned as `Number::NaturalNumber`.** A result that is
+mathematically a whole number comes back as a natural number whatever produced it:
+`2.5+2.5` is `5`, `1/cos(0)` is `1`, `6/3` is `2`, and `Session::setf("x", 4.0)` stores
+`4` rather than `4.0`. `Number::DecimalNumber` now appears only when the value genuinely
+has a fractional part, so every mathematical value has exactly one representation. Code
+that matched on the variant to decide how to render or convert a result may need
+adjusting; code that compares or converts values is unaffected, since equality and
+ordering compare values across the two variants.
+
+**Results that exceed the size budget are refused instead of computed.** Every
+evaluation is now bounded by `Limits::max_value_bits`, 1 Mibit by default, roughly
+315,000 decimal digits. Expressions such as `999999999!` or `10^100000000` return an
+error immediately instead of running until they exhaust memory; where the size can be
+predicted, the refusal happens before any of the work is done. The bound is
+configurable per session through `Session::with_limits`, and it applies to every value
+on the evaluation stack, literals included.
+
+**A function name must be followed by `(`.** `sin 5` and `sqrt 16` were previously
+accepted and evaluated as `sin(5)` and `sqrt(16)`; they are now parse errors that name
+the function. Argument counts are checked at the same point, so `max(1)` and `sin(1,2)`
+report the function, the expected count and the given count, rather than failing later
+as a generic malformed expression.
+
 ## Work order
 
 `D → A → B → C`, deliberately:

--- a/docs/superpowers/specs/2026-08-04-reliable-core-design.md
+++ b/docs/superpowers/specs/2026-08-04-reliable-core-design.md
@@ -79,9 +79,21 @@ representations never coexist. Both are done anyway because `Number` is a **publ
 any consumer can construct `Number::DecimalNumber(BigRational::from_integer(2.into()))`
 by hand. The invariant protects our code, value-based `PartialEq` protects us from theirs.
 
-A welcome side effect: the tests in `session.rs` that assert `DecimalNumber(-5.0)` keep
-passing once the result becomes `NaturalNumber(-5)`, because equality is by value. This
-must be confirmed by running them, not assumed.
+The tests in `session.rs` that assert `DecimalNumber(-5.0)` keep passing once the result
+becomes `NaturalNumber(-5)`, because equality is by value.
+
+**The integration tests do not all survive, and that was checked rather than assumed.**
+The `resolve_decimal!` macro (`tests/integration_tests.rs:17`) asserts the *variant* as
+well, through `matches!(result, Number::DecimalNumber(_))`, across roughly 80 call sites.
+Under the invariant every integral result — `3*2^3+6/(2+1)`, `sqrt(16)`, `exp(0)`,
+`floor(3.7)` — becomes a `NaturalNumber` and those assertions fail.
+
+The repair is one line, not eighty. Those assertions never expressed intended behaviour;
+they photographed the enum tag as a side effect of the macro's name. The property worth
+asserting is the value, which the macro already checks separately. So the macro drops the
+variant assertion, and the invariant gains two dedicated tests that state it outright:
+integral results are `NaturalNumber`, non-integral results stay `DecimalNumber`. Eighty
+incidental assertions become two intentional ones.
 
 ### B. Size limits — closes defect 3
 

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -1,0 +1,152 @@
+# Tech debt
+
+Known structural and maintainability debt, and follow-up work deliberately left
+undone. Every entry below was verified against the source at `3104971`, the head
+of the Stage 1 reliable-core work.
+
+Entries name files and symbols rather than line numbers: line numbers drift, and
+half of those recorded during Stage 1 were stale within a day.
+
+Nothing here is a known wrong answer. The Stage 1 review found no incorrect
+result, no reachable panic on any evaluation path, and no way to route an
+expression around a size guard. These are the things worth fixing next, not
+things that are broken now.
+
+## Structural
+
+**`impl Div for Number` panics on a zero divisor.** It builds
+`BigRational::new(v1, v2)`, which panics when `v2` is zero. Unreachable through
+evaluation — `RpnResolver::resolve` guards against a zero right operand before
+dividing — but this is a public `std::ops` impl that panics on ordinary input, so
+a consumer using `Number` directly can hit it. Fixing it requires `Div` to become
+fallible, which is a breaking API change; it belongs with Stage 2's typed-error
+pass rather than on its own.
+
+**`Token::operator_priority` panics on an unrecognised operator**
+(`_ => panic!("Operator '{o}' not recognised. This must not happen!")`). Reachable
+from the public `Token::compare_operator_priority`. Same shape and same home as
+the entry above: it wants a `Result`, which is a breaking change.
+
+**Four functions exceed the 100-line clippy threshold**, measured at `3104971`:
+`RpnResolver::reverse_polish_notation` at 168, `RpnResolver::resolve` at 155,
+`functions::eval` at 108, and the `test_expressions` integration test at 107. All
+four were already over before Stage 1, but `reverse_polish_notation` grew during
+it, in Task 3 and again in Task 4. This is the clearest structural debt Stage 1
+leaves behind. `reverse_polish_notation` is a single `match` over token kinds
+with the bracket-frame bookkeeping interleaved; the arms are separable.
+
+**`functions::eval`'s match arms are repetitive.** The trigonometric arms differ
+only by the `f64` method they call. Folding them into a helper was deliberately
+not done during Stage 1 because Tasks 2 through 4 all extended the same match and
+the conflict was not worth it. That constraint is gone now.
+
+**`Limits` is not `#[non_exhaustive]`**, and it has one field. Adding a second
+knob later is a breaking change unless this is decided before 0.3.0 ships.
+
+**`Session` exposes no accessor for its limits**, and its `variable_heap` is
+private, so there is no way to evaluate against an existing variable heap under
+different limits. An embedder wanting "tight budget for untrusted input, loose
+for trusted, same variables" has to rebuild the heap themselves through
+`RpnResolver::parse_with_borrowed_heap`. Fine for Stage 1's scope; it belongs in
+Stage 2's API pass.
+
+## Performance
+
+**`parse_decimal_literal` is quadratic in the number of fractional digits.** It
+builds the denominator with a `for _ in 0..fractional_digits` loop of bignum
+multiplications rather than one `pow`. Measured at 1.54 s for a 200,000-digit
+fractional literal. Bounded by input length and outside the size budget's reach,
+since the budget checks the value after it has been built.
+
+**`apply_functional_token_operation` clones its right operand needlessly.** It
+does `match (ln, rn.clone())` and the match consumes both by value, so the clone
+is never used. Under the 1 Mibit budget that is up to roughly 128 KB copied on
+every `+`, `-`, `*` and `/`.
+
+**`RpnResolver::factorial_helper` is the naive sequential product.** Binary
+splitting would decouple running time from the bit budget. Only worth doing if
+someone actually raises `Limits::max_value_bits` — at the 1 Mibit default the
+worst admitted case, `71421!`, takes about 0.43 s in release. This is the reason
+`max_value_bits`' doc warns that time scales superlinearly with the budget.
+
+## Deferred from the Stage 1 review
+
+Small items raised by reviewers, judged not worth their own fix round at the
+time. Each was verified as still open at `3104971`.
+
+**`Number::decimal` checks `denom().is_one()` rather than reducing.** An
+externally built `Ratio::new_raw(4, 2)` is integral but unreduced, so it slips
+past the canonicalisation invariant and becomes a `DecimalNumber(4/2)`. That same
+value also makes `PartialEq` and `PartialOrd` disagree. One-line fix:
+`value.reduced()`. Not reachable through parsing — the parser never produces an
+unreduced rational — so this is about the public constructor's contract.
+
+**`setf` silently does nothing when given NaN or infinity.**
+`BigRational::from_float` returns `None` and the `if let Some(value)` has no
+`else`, so the variable is simply never set and the caller is not told. The
+rewritten doc comment does not mention it.
+
+**Untested behaviours:**
+
+- `2.0!` returns `2` since canonicalisation landed, where it used to error. User
+  visible, and pinned by nothing.
+- `1/0.0` — the decimal-literal form of division by zero, which used to panic and
+  was incidentally fixed by canonicalisation. `1/0` is tested; the form that
+  actually panicked is not.
+- The canonicalisation invariant test never reaches `Div` Decimal/Decimal, the
+  `apply_functional_token_operation` decimal arms, or `power_integer`'s decimal
+  arms. Adding `0.5+0.5`, `1.5/0.5` and `(0.5)^-1` to the existing loop covers
+  all three.
+- `(-1)^odd`. Only the even-exponent degenerate case is pinned.
+- Exponent zero, the `n = 0` and `n = 1` factorial early returns, and an
+  expression landing exactly on the size budget.
+
+**Diagnostics that are still generic or slightly wrong:**
+
+- A bare `()` outside a function call falls through to the generic
+  malformed-expression message. Pre-existing.
+- `COMMA_OUTSIDE_CALL_ERR`'s wording misdescribes the nested case: a comma inside
+  a plain bracket nested within a call reads as if no call were open at all.
+- `sin[5]` evaluates, because `[` and `]` are bracket aliases, while the error
+  text and the README both say a function must be followed by `(`. Either the
+  aliases or the wording should give way.
+- `max(1,*2)` passes the arity check with `given == 2` and fails later at
+  evaluation. Operator-sequence validation is deferred to Stage 2 by design; this
+  is the visible edge of that gap.
+
+**Polish:**
+
+- `resolve_decimal!` no longer asserts the decimal variant, so the name is a
+  misnomer. `resolve_approx!` would read truer.
+- `EXPONENT_TOO_LARGE_ERR` is lowercase after `Runtime error:`, unlike its
+  siblings in `rpn_resolver.rs`, though consistent with `limits.rs`.
+- Two `#[allow]` attributes on `predicted_factorial_bits` where `#[expect(...)]`
+  would self-report once the casts stop needing suppression.
+- `test_max_min` is a single loop over three expressions, so a failure on the
+  first skips the other two.
+- Several README fenced blocks holding CLI transcripts and the built-in function
+  list are tagged ```rust. Pre-existing mislabelling.
+
+## A pattern worth remembering
+
+Four times during Stage 1, a test passed for a reason other than the one it
+named, because a **different** guard caught its input first:
+
+- `test_growth_through_multiplication_is_caught` was meant to exercise the
+  post-hoc `Mul` check, but with the original budget the power prediction refused
+  the input before any multiplication ran.
+- The variable-budget test was first drafted as `"x+1"`, where the `Add` arm's
+  existing `check_size` would have fired instead of the variable push under test.
+  The committed test uses bare `"x"`.
+- `2!` cannot demonstrate the factorial prediction's one-bit shortfall, because
+  the operand check rejects the literal `2` first. The only route to an unchecked
+  `2` is a function result.
+- Closing the function arm then made the factorial's own post-hoc check
+  unreachable, so the test that had just been written to cover it started passing
+  for a third reason again.
+
+A guard that is correct only because something upstream shields it looks tested
+when it is merely shadowed. Two things catch it: assert *which* check fired, by
+its distinctive wording, rather than merely that an error occurred; and where two
+wordings cannot be told apart, break the guard on purpose and confirm the test
+goes red.

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -59,10 +59,10 @@ pub(crate) fn eval(
             number_to_f64(&value, FLOAT_EVAL_TOO_LARGE_ERR)?.log10(),
             INVALID_FUNCTION_RESULT_ERR,
         )?,
-        MathFunction::Abs => to_decimal_number(match value {
+        MathFunction::Abs => match value {
             Number::NaturalNumber(v) => Number::NaturalNumber(v.abs()),
-            Number::DecimalNumber(v) => Number::DecimalNumber(v.abs()),
-        }),
+            Number::DecimalNumber(v) => Number::decimal(v.abs()),
+        },
         MathFunction::Max => {
             let value2: Number = result_stack.pop_back().ok_or(anyhow!(
                 "{} {}",
@@ -70,7 +70,11 @@ pub(crate) fn eval(
                 "Wrong number of parameters for function Max"
             ))?;
             var_stack.pop_back();
-            to_decimal_number(if value >= value2 { value } else { value2 })
+            if value >= value2 {
+                value
+            } else {
+                value2
+            }
         }
         MathFunction::Min => {
             let value2: Number = result_stack.pop_back().ok_or(anyhow!(
@@ -79,7 +83,11 @@ pub(crate) fn eval(
                 "Wrong number of parameters for function Min"
             ))?;
             var_stack.pop_back();
-            to_decimal_number(if value <= value2 { value } else { value2 })
+            if value <= value2 {
+                value
+            } else {
+                value2
+            }
         }
         MathFunction::Sqrt => decimal_from_f64(
             number_to_f64(&value, FLOAT_EVAL_TOO_LARGE_ERR)?.sqrt(),
@@ -87,13 +95,11 @@ pub(crate) fn eval(
         )?,
         MathFunction::Floor => {
             let value = number_to_rational(value);
-            to_decimal_number(Number::NaturalNumber(
-                value.numer().div_floor(value.denom()),
-            ))
+            Number::NaturalNumber(value.numer().div_floor(value.denom()))
         }
         MathFunction::Ceil => {
             let value = number_to_rational(value);
-            to_decimal_number(Number::NaturalNumber(value.numer().div_ceil(value.denom())))
+            Number::NaturalNumber(value.numer().div_ceil(value.denom()))
         }
         MathFunction::Round => {
             let value = number_to_rational(value);
@@ -105,7 +111,7 @@ pub(crate) fn eval(
             } else {
                 (doubled_numer - denom).div_ceil(&doubled_denom)
             };
-            to_decimal_number(Number::NaturalNumber(rounded))
+            Number::NaturalNumber(rounded)
         }
         MathFunction::Pdf => {
             let normal = Normal::new(0.0, 1.0).expect("valid normal dist");
@@ -143,7 +149,7 @@ pub(crate) fn decimal_from_f64(value: f64, error_message: &'static str) -> anyho
     }
 
     BigRational::from_float(value)
-        .map(Number::DecimalNumber)
+        .map(Number::decimal)
         .ok_or_else(|| anyhow!(error_message))
 }
 
@@ -151,12 +157,5 @@ pub(crate) fn number_to_rational(value: Number) -> BigRational {
     match value {
         Number::NaturalNumber(v) => BigRational::from_integer(v),
         Number::DecimalNumber(v) => v,
-    }
-}
-
-pub(crate) fn to_decimal_number(value: Number) -> Number {
-    match value {
-        Number::NaturalNumber(v) => Number::DecimalNumber(BigRational::from_integer(v)),
-        Number::DecimalNumber(v) => Number::DecimalNumber(v),
     }
 }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -1,0 +1,162 @@
+//! Evaluation of the built-in mathematical functions, together with the
+//! numeric conversions they rely on.
+//!
+//! Split out of [`crate::rpn_resolver`], which owns the shunting-yard
+//! translation and the evaluation loop; this module owns what happens when
+//! that loop meets a [`MathFunction`].
+
+use crate::rpn_resolver::{FLOAT_EVAL_TOO_LARGE_ERR, INVALID_FUNCTION_RESULT_ERR, MALFORMED_ERR};
+use crate::token::{MathFunction, Number};
+use anyhow::anyhow;
+use num::{Integer, Signed};
+use num_bigint::BigInt;
+use num_rational::BigRational;
+use num_traits::{ToPrimitive, Zero};
+use statrs::distribution::{Continuous, ContinuousCDF, Normal};
+use std::collections::VecDeque;
+
+/// Evaluates `fun` against `value`, the operand already popped by the caller.
+///
+/// A two-argument function pops its second operand from `result_stack` itself,
+/// keeping `var_stack` in step. Both stacks belong to the evaluation loop in
+/// [`crate::rpn_resolver::RpnResolver::resolve`].
+pub(crate) fn eval(
+    fun: MathFunction,
+    value: Number,
+    result_stack: &mut VecDeque<Number>,
+    var_stack: &mut VecDeque<Option<String>>,
+) -> anyhow::Result<Number> {
+    let result = match fun {
+        MathFunction::Sin => decimal_from_f64(
+            number_to_f64(&value, FLOAT_EVAL_TOO_LARGE_ERR)?.sin(),
+            INVALID_FUNCTION_RESULT_ERR,
+        )?,
+        MathFunction::Cos => decimal_from_f64(
+            number_to_f64(&value, FLOAT_EVAL_TOO_LARGE_ERR)?.cos(),
+            INVALID_FUNCTION_RESULT_ERR,
+        )?,
+        MathFunction::Tan => decimal_from_f64(
+            number_to_f64(&value, FLOAT_EVAL_TOO_LARGE_ERR)?.tan(),
+            INVALID_FUNCTION_RESULT_ERR,
+        )?,
+        MathFunction::ASin => decimal_from_f64(
+            number_to_f64(&value, FLOAT_EVAL_TOO_LARGE_ERR)?.asin(),
+            INVALID_FUNCTION_RESULT_ERR,
+        )?,
+        MathFunction::ACos => decimal_from_f64(
+            number_to_f64(&value, FLOAT_EVAL_TOO_LARGE_ERR)?.acos(),
+            INVALID_FUNCTION_RESULT_ERR,
+        )?,
+        MathFunction::ATan => decimal_from_f64(
+            number_to_f64(&value, FLOAT_EVAL_TOO_LARGE_ERR)?.atan(),
+            INVALID_FUNCTION_RESULT_ERR,
+        )?,
+        MathFunction::Ln => decimal_from_f64(
+            number_to_f64(&value, FLOAT_EVAL_TOO_LARGE_ERR)?.ln(),
+            INVALID_FUNCTION_RESULT_ERR,
+        )?,
+        MathFunction::Log => decimal_from_f64(
+            number_to_f64(&value, FLOAT_EVAL_TOO_LARGE_ERR)?.log10(),
+            INVALID_FUNCTION_RESULT_ERR,
+        )?,
+        MathFunction::Abs => to_decimal_number(match value {
+            Number::NaturalNumber(v) => Number::NaturalNumber(v.abs()),
+            Number::DecimalNumber(v) => Number::DecimalNumber(v.abs()),
+        }),
+        MathFunction::Max => {
+            let value2: Number = result_stack.pop_back().ok_or(anyhow!(
+                "{} {}",
+                MALFORMED_ERR,
+                "Wrong number of parameters for function Max"
+            ))?;
+            var_stack.pop_back();
+            to_decimal_number(if value >= value2 { value } else { value2 })
+        }
+        MathFunction::Min => {
+            let value2: Number = result_stack.pop_back().ok_or(anyhow!(
+                "{} {}",
+                MALFORMED_ERR,
+                "Wrong number of parameters for function Min"
+            ))?;
+            var_stack.pop_back();
+            to_decimal_number(if value <= value2 { value } else { value2 })
+        }
+        MathFunction::Sqrt => decimal_from_f64(
+            number_to_f64(&value, FLOAT_EVAL_TOO_LARGE_ERR)?.sqrt(),
+            INVALID_FUNCTION_RESULT_ERR,
+        )?,
+        MathFunction::Floor => {
+            let value = number_to_rational(value);
+            to_decimal_number(Number::NaturalNumber(
+                value.numer().div_floor(value.denom()),
+            ))
+        }
+        MathFunction::Ceil => {
+            let value = number_to_rational(value);
+            to_decimal_number(Number::NaturalNumber(value.numer().div_ceil(value.denom())))
+        }
+        MathFunction::Round => {
+            let value = number_to_rational(value);
+            let denom = value.denom().clone();
+            let doubled_numer = value.numer().clone() * BigInt::from(2_u8);
+            let doubled_denom = denom.clone() * BigInt::from(2_u8);
+            let rounded = if doubled_numer >= BigInt::zero() {
+                (doubled_numer + denom).div_floor(&doubled_denom)
+            } else {
+                (doubled_numer - denom).div_ceil(&doubled_denom)
+            };
+            to_decimal_number(Number::NaturalNumber(rounded))
+        }
+        MathFunction::Pdf => {
+            let normal = Normal::new(0.0, 1.0).expect("valid normal dist");
+            decimal_from_f64(
+                normal.pdf(number_to_f64(&value, FLOAT_EVAL_TOO_LARGE_ERR)?),
+                INVALID_FUNCTION_RESULT_ERR,
+            )?
+        }
+        MathFunction::Cdf => {
+            let normal = Normal::new(0.0, 1.0).expect("valid normal dist");
+            decimal_from_f64(
+                normal.cdf(number_to_f64(&value, FLOAT_EVAL_TOO_LARGE_ERR)?),
+                INVALID_FUNCTION_RESULT_ERR,
+            )?
+        }
+        MathFunction::Exp => decimal_from_f64(
+            number_to_f64(&value, FLOAT_EVAL_TOO_LARGE_ERR)?.exp(),
+            INVALID_FUNCTION_RESULT_ERR,
+        )?,
+        MathFunction::None => return Err(anyhow!("This should never happen!")),
+    };
+    Ok(result)
+}
+
+pub(crate) fn number_to_f64(value: &Number, error_message: &'static str) -> anyhow::Result<f64> {
+    match value {
+        Number::NaturalNumber(v) => v.to_f64().ok_or_else(|| anyhow!(error_message)),
+        Number::DecimalNumber(v) => v.to_f64().ok_or_else(|| anyhow!(error_message)),
+    }
+}
+
+pub(crate) fn decimal_from_f64(value: f64, error_message: &'static str) -> anyhow::Result<Number> {
+    if !value.is_finite() {
+        return Err(anyhow!(error_message));
+    }
+
+    BigRational::from_float(value)
+        .map(Number::DecimalNumber)
+        .ok_or_else(|| anyhow!(error_message))
+}
+
+pub(crate) fn number_to_rational(value: Number) -> BigRational {
+    match value {
+        Number::NaturalNumber(v) => BigRational::from_integer(v),
+        Number::DecimalNumber(v) => v,
+    }
+}
+
+pub(crate) fn to_decimal_number(value: Number) -> Number {
+    match value {
+        Number::NaturalNumber(v) => Number::DecimalNumber(BigRational::from_integer(v)),
+        Number::DecimalNumber(v) => Number::DecimalNumber(v),
+    }
+}

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -17,9 +17,11 @@ use std::collections::VecDeque;
 
 /// Evaluates `fun` against `value`, the operand already popped by the caller.
 ///
-/// A two-argument function pops its second operand from `result_stack` itself,
-/// keeping `var_stack` in step. Both stacks belong to the evaluation loop in
-/// [`crate::rpn_resolver::RpnResolver::resolve`].
+/// For a two-argument function that operand is the *second* argument, since the
+/// caller popped the top of the stack and postfix order puts the second argument
+/// there. What this function pops from `result_stack` is therefore the *first*
+/// argument, keeping `var_stack` in step. Both stacks belong to the evaluation
+/// loop in [`crate::rpn_resolver::RpnResolver::resolve`].
 pub(crate) fn eval(
     fun: MathFunction,
     value: Number,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,8 @@
 //! ```
 /// Built-in function evaluation
 mod functions;
+/// Evaluation limits
+pub mod limits;
 /// Parser
 pub mod parser;
 /// `RpnResolver`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,8 @@
 //! Pdf
 //! Cdf
 //! ```
+//!
+//! Function arguments are always parenthesised: `sqrt(16)`, `max(1,2)`.
 /// Built-in function evaluation
 mod functions;
 /// Evaluation limits

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,12 @@
 //!  ```
 //!
 //! All that's needed is to create a new instance of the [`RpnResolver`] and hand over the expression to be analysed.
-//! The library just returns a variant natural number, or a decimal number if one exists in the expression (i.e '2.1+1') or there's a trigonometric function (i.e. 1/cos(x+1)).
+//! The library returns a [`Number`](crate::token::Number), and the value decides which variant, not the
+//! expression that produced it. An integral result always comes back as
+//! [`Number::NaturalNumber`](crate::token::Number::NaturalNumber), whatever it came from — `2.5+2.5` is `5`,
+//! `1/cos(0)` is `1`, `6/3` is `2`. [`Number::DecimalNumber`](crate::token::Number::DecimalNumber) appears only
+//! when the value genuinely has a fractional part, as in `0.1+0.2` or `1/3`. Every mathematical value therefore
+//! has exactly one representation.
 //!
 //! Yarer can handle also variables and functions. Here an example:
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,8 @@
 //! Pdf
 //! Cdf
 //! ```
+/// Built-in function evaluation
+mod functions;
 /// Parser
 pub mod parser;
 /// `RpnResolver`

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -27,12 +27,10 @@ use num_traits::ToPrimitive;
 /// Resource bounds applied while evaluating an expression.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Limits {
-    /// The largest value a literal, a variable or an arithmetic result may
-    /// occupy, in bits.
-    ///
-    /// Function results are the one thing it does not cover: every built-in
-    /// routes its argument through `f64`, so what they return is bounded far
-    /// below any practical budget by construction rather than by this check.
+    /// The largest value any intermediate or final result may occupy, in bits.
+    /// Every value pushed onto the evaluation stack is measured against it,
+    /// whatever produced it — literal, variable, arithmetic result or function
+    /// result — with no exceptions.
     ///
     /// This bounds memory directly and worst-case running time only indirectly,
     /// and the second relationship is superlinear, so raise it with the measured

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -13,6 +13,14 @@ use num_traits::ToPrimitive;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Limits {
     /// The largest value any intermediate or final result may occupy, in bits.
+    ///
+    /// This bounds memory directly and worst-case running time only indirectly,
+    /// and the second relationship is superlinear: a factorial is a loop of `n`
+    /// bignum multiplications, so quadrupling this budget costs roughly twelve
+    /// times the worst-case factorial time. At the 1 Mibit default the largest
+    /// factorial admitted is `71421!`, measured at about 0.43 s in a release
+    /// build. Raise the budget with that ratio in mind rather than in the
+    /// expectation that time scales with it.
     pub max_value_bits: u64,
 }
 

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -32,12 +32,25 @@ pub fn size_in_bits(value: &Number) -> u64 {
     }
 }
 
+/// Compares `bits` against the budget, wording the error for whichever of the two
+/// callers below is asking: a value already computed occupies a size, while a
+/// computation not yet run only has a predicted one.
+fn check_bits(bits: u128, limits: Limits, phrase: &str) -> anyhow::Result<()> {
+    if bits > u128::from(limits.max_value_bits) {
+        return Err(anyhow!(
+            "Runtime error: the result {phrase} about {bits} bits, over the size limit of {} bits.",
+            limits.max_value_bits
+        ));
+    }
+    Ok(())
+}
+
 /// Rejects a value that has already been computed and turned out too large.
 ///
 /// # Errors
 /// When the value exceeds `limits.max_value_bits`.
 pub fn check_size(value: &Number, limits: Limits) -> anyhow::Result<()> {
-    check_predicted_size(u128::from(size_in_bits(value)), limits)
+    check_bits(u128::from(size_in_bits(value)), limits, "occupies")
 }
 
 /// Rejects a computation whose result was predicted to be too large, before it runs.
@@ -45,13 +58,7 @@ pub fn check_size(value: &Number, limits: Limits) -> anyhow::Result<()> {
 /// # Errors
 /// When `predicted_bits` exceeds `limits.max_value_bits`.
 pub fn check_predicted_size(predicted_bits: u128, limits: Limits) -> anyhow::Result<()> {
-    if predicted_bits > u128::from(limits.max_value_bits) {
-        return Err(anyhow!(
-            "Runtime error: the result would need about {predicted_bits} bits, over the size limit of {} bits.",
-            limits.max_value_bits
-        ));
-    }
-    Ok(())
+    check_bits(predicted_bits, limits, "would need")
 }
 
 /// Predicts the bit length of `n!` without computing it, via Stirling's series:
@@ -60,9 +67,12 @@ pub fn check_predicted_size(predicted_bits: u128, limits: Limits) -> anyhow::Res
 /// The first two terms alone are optimistic — they omit the `0.5·log2(2πn)` term,
 /// which for `n` in the hundreds of thousands is close to ten bits, enough to let a
 /// prediction land just under a tight budget while the true value lands just over
-/// it. With the correction included this matches `lgamma(n+1)/ln(2)` to under a bit
-/// across tested magnitudes, so — like the power prediction, which overestimates
-/// for the opposite reason — this one no longer underestimates the size it guards.
+/// it. With the correction included this matches `lgamma(n+1)/ln(2)` to within about
+/// a bit, a large improvement, but not an exact lower bound: the series is still
+/// asymptotic, and `.ceil()` of a value just below an integer can still round to one
+/// bit less than the true bit count — at `n = 2` the raw estimate is `0.94`, which
+/// ceils to `1`, while `2!` needs `2` bits. So the remaining exposure is about a bit,
+/// not zero, in either direction.
 ///
 /// This is still an estimate, not an exact count, so the precision lost converting
 /// `n` to `f64` and the truncation converting the rounded-up estimate back to
@@ -89,13 +99,24 @@ pub fn predicted_factorial_bits(n: u64) -> u128 {
 
 /// An upper bound on the bit length of `base^exponent` for an integral exponent.
 ///
-/// It uses `bits(base)` where `log2(base)` would be exact, so it overestimates by
-/// up to a factor of two for small bases — `2^100` is predicted at 200 bits and
-/// occupies 101. A guard that errs toward refusing is the right direction to err in,
-/// and the discrepancy only matters within a factor of two of the budget.
+/// Degenerate bases are special-cased first: when `base`'s magnitude is 0 or 1, so
+/// is the magnitude of any power of it, regardless of how large the exponent is, so
+/// the exponent is irrelevant and no prediction is needed. Without this, `base_bits`
+/// would be clamped up to 1 by `.max(1)` and multiplied by the exponent, turning a
+/// computation that is actually free — `1^10000000` is `1`, computed instantly — into
+/// one refused for needing ten million bits.
+///
+/// For every other base it uses `bits(base)` where `log2(base)` would be exact, so
+/// it overestimates by up to a factor of two for small bases — `2^100` is predicted
+/// at 200 bits and occupies 101. A guard that errs toward refusing is the right
+/// direction to err in, and the discrepancy only matters within a factor of two of
+/// the budget.
 #[must_use]
 pub fn predicted_power_bits(base: &Number, exponent_magnitude: u64) -> u128 {
-    let base_bits = size_in_bits(base).max(1);
+    let base_bits = size_in_bits(base);
+    if base_bits <= 1 {
+        return 1;
+    }
     u128::from(base_bits) * u128::from(exponent_magnitude)
 }
 
@@ -112,19 +133,33 @@ mod tests {
     }
 
     #[test]
-    fn test_factorial_prediction_is_in_the_right_ballpark() {
-        // 1000! is 8529 bits; Stirling must land close and never far under.
-        let predicted = predicted_factorial_bits(1000);
-        assert!(
-            (8000..=9200).contains(&predicted),
-            "predicted {predicted} bits for 1000!"
-        );
+    fn test_factorial_prediction_matches_stirling_with_correction() {
+        // 1000! is 8529 bits (lgamma(1001)/ln(2) = 8529.4); the three-term series
+        // used here predicts 8530. A wide "ballpark" range does not pin this down:
+        // dropping the 0.5*log2(2*pi*n) correction term still predicts 8524, which
+        // is inside almost any range wide enough to be useful, so only an exact
+        // value catches the correction term going missing.
+        assert_eq!(predicted_factorial_bits(1000), 8530);
     }
 
     #[test]
     fn test_power_prediction_multiplies_base_size_by_exponent() {
         let ten = Number::NaturalNumber(BigInt::from(10));
         assert_eq!(predicted_power_bits(&ten, 100), 400);
+    }
+
+    #[test]
+    fn test_power_prediction_ignores_the_exponent_for_degenerate_bases() {
+        // 1^n, 0^n and (-1)^n all have magnitude 0 or 1 no matter how large n is,
+        // so a huge exponent must not inflate the prediction: base_bits.max(1) *
+        // exponent_magnitude would otherwise turn a free computation into a refusal.
+        for base in [
+            Number::NaturalNumber(BigInt::from(1)),
+            Number::NaturalNumber(BigInt::from(0)),
+            Number::NaturalNumber(BigInt::from(-1)),
+        ] {
+            assert_eq!(predicted_power_bits(&base, 10_000_000), 1);
+        }
     }
 
     #[test]

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -1,8 +1,23 @@
 //! Bounds on how large a value an evaluation may produce.
 //!
-//! The strategy is to predict the size of a result and refuse before computing
-//! it, rather than computing under a timeout: no threads, no interruption, and
-//! a decision that is deterministic and instantaneous.
+//! Two checks, with different jobs. **Predict to avoid the work, verify to be
+//! correct.**
+//!
+//! `check_predicted_size` runs before an expensive computation and refuses it
+//! on an estimate, which is what lets `999999999!` be declined in milliseconds
+//! instead of running until it exhausts memory. That is an optimisation, and an
+//! estimate is all it can be: it is beaten by any path that has no prediction
+//! (`2^0.5` goes through `f64`) and by any prediction that measures something
+//! other than the value finally returned (`2^-1` predicts the magnitude of
+//! `2^1` and returns its reciprocal).
+//!
+//! `check_size` runs on the value that was actually built, and is the
+//! guarantee. It is exact by construction, because it measures rather than
+//! estimates. Predictions may be tightened or added freely; correctness does not
+//! rest on them.
+//!
+//! Refusing rather than computing under a timeout keeps the decision
+//! deterministic and instantaneous: no threads, no interruption.
 
 use crate::token::Number;
 use anyhow::anyhow;
@@ -69,6 +84,10 @@ fn check_bits(bits: u128, limits: Limits, phrase: &str) -> anyhow::Result<()> {
 
 /// Rejects a value that has already been computed and turned out too large.
 ///
+/// This is the budget's guarantee: it measures the value in hand, so it holds
+/// regardless of whether a prediction ran first, or ran accurately. Every path
+/// that produces a value applies it.
+///
 /// # Errors
 /// When the value exceeds `limits.max_value_bits`.
 pub(crate) fn check_size(value: &Number, limits: Limits) -> anyhow::Result<()> {
@@ -76,6 +95,10 @@ pub(crate) fn check_size(value: &Number, limits: Limits) -> anyhow::Result<()> {
 }
 
 /// Rejects a computation whose result was predicted to be too large, before it runs.
+///
+/// A pre-filter, not the guarantee — see the module docs. Its purpose is to make
+/// a hopeless computation cheap to refuse; being approximate is acceptable
+/// because [`check_size`] measures the result afterwards either way.
 ///
 /// # Errors
 /// When `predicted_bits` exceeds `limits.max_value_bits`.
@@ -95,6 +118,13 @@ pub(crate) fn check_predicted_size(predicted_bits: u128, limits: Limits) -> anyh
 /// bit less than the true bit count — at `n = 2` the raw estimate is `0.94`, which
 /// ceils to `1`, while `2!` needs `2` bits. So the remaining exposure is about a bit,
 /// not zero, in either direction.
+///
+/// That exposure is a performance detail rather than a correctness one, because
+/// this is a pre-filter and [`check_size`] measures the factorial afterwards. An
+/// over-estimate refuses a computation that would have fitted, by about a bit; an
+/// under-estimate lets one start that is then refused on measurement. Neither can
+/// admit an oversized value. `n = 2` is the only under-estimate for any `n` up to
+/// 60000, verified by computing `n!` and comparing bit lengths.
 ///
 /// This is still an estimate, not an exact count, so the precision lost converting
 /// `n` to `f64` and the truncation converting the rounded-up estimate back to
@@ -119,8 +149,17 @@ pub(crate) fn predicted_factorial_bits(n: u64) -> u128 {
     bits.max(1.0).ceil() as u128
 }
 
-/// An upper bound on the bit length of `base^exponent` for an integral exponent,
-/// or [`None`] when the exponent is too large for the prediction to be made at all.
+/// An estimate of the bit length of `base` raised to the *magnitude* of an
+/// integral exponent, or [`None`] when that magnitude is too large for the
+/// estimate to be made at all.
+///
+/// Note the "magnitude": a negative exponent returns the reciprocal, and
+/// [`size_in_bits`] counts a rational's denominator as well as its numerator, so
+/// this is **not** an upper bound on what the caller ends up holding. `2^-1`
+/// estimates 2 bits and produces `1/2`, which measures `1 + 2 = 3`. Correcting
+/// that here would only narrow the gap, not close it, since the `powf` path has
+/// no prediction at all; [`check_size`] on the finished value is what makes the
+/// budget exact, and this stays a pre-filter.
 ///
 /// Degenerate bases are special-cased first: when `base`'s magnitude is 0 or 1, so
 /// is the magnitude of any power of it, regardless of how large the exponent is, so
@@ -137,9 +176,10 @@ pub(crate) fn predicted_factorial_bits(n: u64) -> u128 {
 ///
 /// For every other base it uses `bits(base)` where `log2(base)` would be exact, so
 /// it overestimates by up to a factor of two for small bases — `2^100` is predicted
-/// at 200 bits and occupies 101. A guard that errs toward refusing is the right
-/// direction to err in, and the discrepancy only matters within a factor of two of
-/// the budget.
+/// at 200 bits and occupies 101. For a pre-filter, erring toward refusing is the
+/// right direction to err in: the cost is a computation declined that would have
+/// fitted, within a factor of two of the budget, and never an oversized value
+/// admitted.
 #[must_use]
 pub(crate) fn predicted_power_bits(base: &Number, exponent_magnitude: &BigUint) -> Option<u128> {
     let base_bits = size_in_bits(base);
@@ -199,6 +239,19 @@ mod tests {
             );
             assert_eq!(predicted_power_bits(&base, &beyond_u64), Some(1));
         }
+    }
+
+    #[test]
+    fn test_power_prediction_is_not_an_upper_bound_for_a_negative_exponent() {
+        // The prediction is made on the magnitude, so it describes 2^1 and not
+        // the 1/2 a negative exponent actually returns. Pinning the gap here
+        // documents why check_size on the finished value is load-bearing rather
+        // than belt-and-braces: at a 2-bit budget the prediction admits, and the
+        // value measures 3.
+        let two = Number::NaturalNumber(BigInt::from(2));
+        assert_eq!(predicted_power_bits(&two, &BigUint::from(1_u32)), Some(2));
+        let half = Number::DecimalNumber(BigRational::new(BigInt::from(1), BigInt::from(2)));
+        assert_eq!(size_in_bits(&half), 3);
     }
 
     #[test]

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -1,0 +1,126 @@
+//! Bounds on how large a value an evaluation may produce.
+//!
+//! The strategy is to predict the size of a result and refuse before computing
+//! it, rather than computing under a timeout: no threads, no interruption, and
+//! a decision that is deterministic and instantaneous.
+
+use crate::token::Number;
+use anyhow::anyhow;
+
+/// Resource bounds applied while evaluating an expression.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Limits {
+    /// The largest value any intermediate or final result may occupy, in bits.
+    pub max_value_bits: u64,
+}
+
+impl Default for Limits {
+    /// 1 Mibit, roughly `315_000` decimal digits.
+    fn default() -> Self {
+        Limits {
+            max_value_bits: 1 << 20,
+        }
+    }
+}
+
+/// The size of a value in bits: for a rational, numerator plus denominator.
+#[must_use]
+pub fn size_in_bits(value: &Number) -> u64 {
+    match value {
+        Number::NaturalNumber(v) => v.bits(),
+        Number::DecimalNumber(v) => v.numer().bits() + v.denom().bits(),
+    }
+}
+
+/// Rejects a value that has already been computed and turned out too large.
+///
+/// # Errors
+/// When the value exceeds `limits.max_value_bits`.
+pub fn check_size(value: &Number, limits: Limits) -> anyhow::Result<()> {
+    check_predicted_size(u128::from(size_in_bits(value)), limits)
+}
+
+/// Rejects a computation whose result was predicted to be too large, before it runs.
+///
+/// # Errors
+/// When `predicted_bits` exceeds `limits.max_value_bits`.
+pub fn check_predicted_size(predicted_bits: u128, limits: Limits) -> anyhow::Result<()> {
+    if predicted_bits > u128::from(limits.max_value_bits) {
+        return Err(anyhow!(
+            "Runtime error: the result would need about {predicted_bits} bits, over the size limit of {} bits.",
+            limits.max_value_bits
+        ));
+    }
+    Ok(())
+}
+
+/// Predicts the bit length of `n!` without computing it, via Stirling:
+/// `log2(n!) ≈ n·log2(n) − 1.44·n`.
+///
+/// This is an estimate, not an exact count, so the precision lost converting `n`
+/// to `f64` and the truncation converting the rounded-up estimate back to `u128`
+/// are both intentional: `.max(1.0)` rules out a negative or sub-one result before
+/// the cast, and a saturating cast is the correct outcome for an `n` so large that
+/// the estimate would not fit anyway.
+#[must_use]
+#[allow(clippy::cast_precision_loss)]
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+pub fn predicted_factorial_bits(n: u64) -> u128 {
+    if n < 2 {
+        return 1;
+    }
+    let n_f = n as f64;
+    // -1.442_695_040_888_963_4 is bit-for-bit -LOG2_E; clippy's approx_constant
+    // lint (deny-by-default) requires the named constant instead of the literal.
+    let bits = n_f.mul_add(n_f.log2(), -std::f64::consts::LOG2_E * n_f);
+    // Round up and never report less than one bit.
+    bits.max(1.0).ceil() as u128
+}
+
+/// An upper bound on the bit length of `base^exponent` for an integral exponent.
+///
+/// It uses `bits(base)` where `log2(base)` would be exact, so it overestimates by
+/// up to a factor of two for small bases — `2^100` is predicted at 200 bits and
+/// occupies 101. A guard that errs toward refusing is the right direction to err in,
+/// and the discrepancy only matters within a factor of two of the budget.
+#[must_use]
+pub fn predicted_power_bits(base: &Number, exponent_magnitude: u64) -> u128 {
+    let base_bits = size_in_bits(base).max(1);
+    u128::from(base_bits) * u128::from(exponent_magnitude)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use num_bigint::BigInt;
+    use num_rational::BigRational;
+
+    #[test]
+    fn test_size_of_a_rational_counts_both_halves() {
+        let third = Number::DecimalNumber(BigRational::new(BigInt::from(1), BigInt::from(3)));
+        assert_eq!(size_in_bits(&third), 1 + 2);
+    }
+
+    #[test]
+    fn test_factorial_prediction_is_in_the_right_ballpark() {
+        // 1000! is 8529 bits; Stirling must land close and never far under.
+        let predicted = predicted_factorial_bits(1000);
+        assert!(
+            (8000..=9200).contains(&predicted),
+            "predicted {predicted} bits for 1000!"
+        );
+    }
+
+    #[test]
+    fn test_power_prediction_multiplies_base_size_by_exponent() {
+        let ten = Number::NaturalNumber(BigInt::from(10));
+        assert_eq!(predicted_power_bits(&ten, 100), 400);
+    }
+
+    #[test]
+    fn test_check_rejects_above_the_budget_and_accepts_at_it() {
+        let limits = Limits { max_value_bits: 64 };
+        assert!(check_predicted_size(64, limits).is_ok());
+        assert!(check_predicted_size(65, limits).is_err());
+    }
+}

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -54,14 +54,21 @@ pub fn check_predicted_size(predicted_bits: u128, limits: Limits) -> anyhow::Res
     Ok(())
 }
 
-/// Predicts the bit length of `n!` without computing it, via Stirling:
-/// `log2(n!) ≈ n·log2(n) − 1.44·n`.
+/// Predicts the bit length of `n!` without computing it, via Stirling's series:
+/// `log2(n!) ≈ n·log2(n) − n·log2(e) + 0.5·log2(2πn)`.
 ///
-/// This is an estimate, not an exact count, so the precision lost converting `n`
-/// to `f64` and the truncation converting the rounded-up estimate back to `u128`
-/// are both intentional: `.max(1.0)` rules out a negative or sub-one result before
-/// the cast, and a saturating cast is the correct outcome for an `n` so large that
-/// the estimate would not fit anyway.
+/// The first two terms alone are optimistic — they omit the `0.5·log2(2πn)` term,
+/// which for `n` in the hundreds of thousands is close to ten bits, enough to let a
+/// prediction land just under a tight budget while the true value lands just over
+/// it. With the correction included this matches `lgamma(n+1)/ln(2)` to under a bit
+/// across tested magnitudes, so — like the power prediction, which overestimates
+/// for the opposite reason — this one no longer underestimates the size it guards.
+///
+/// This is still an estimate, not an exact count, so the precision lost converting
+/// `n` to `f64` and the truncation converting the rounded-up estimate back to
+/// `u128` are both intentional: `.max(1.0)` rules out a negative or sub-one result
+/// before the cast, and a saturating cast is the correct outcome for an `n` so
+/// large that the estimate would not fit anyway.
 #[must_use]
 #[allow(clippy::cast_precision_loss)]
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
@@ -72,7 +79,10 @@ pub fn predicted_factorial_bits(n: u64) -> u128 {
     let n_f = n as f64;
     // -1.442_695_040_888_963_4 is bit-for-bit -LOG2_E; clippy's approx_constant
     // lint (deny-by-default) requires the named constant instead of the literal.
-    let bits = n_f.mul_add(n_f.log2(), -std::f64::consts::LOG2_E * n_f);
+    let leading_terms = n_f.mul_add(n_f.log2(), -std::f64::consts::LOG2_E * n_f);
+    // 0.5 * log2(2 * pi * n); TAU is the named constant for 2*pi.
+    let correction = 0.5 * (std::f64::consts::TAU * n_f).log2();
+    let bits = leading_terms + correction;
     // Round up and never report less than one bit.
     bits.max(1.0).ceil() as u128
 }

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -12,15 +12,27 @@ use num_traits::ToPrimitive;
 /// Resource bounds applied while evaluating an expression.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Limits {
-    /// The largest value any intermediate or final result may occupy, in bits.
+    /// The largest value a literal, a variable or an arithmetic result may
+    /// occupy, in bits.
+    ///
+    /// Function results are the one thing it does not cover: every built-in
+    /// routes its argument through `f64`, so what they return is bounded far
+    /// below any practical budget by construction rather than by this check.
     ///
     /// This bounds memory directly and worst-case running time only indirectly,
-    /// and the second relationship is superlinear: a factorial is a loop of `n`
-    /// bignum multiplications, so quadrupling this budget costs roughly twelve
-    /// times the worst-case factorial time. At the 1 Mibit default the largest
-    /// factorial admitted is `71421!`, measured at about 0.43 s in a release
-    /// build. Raise the budget with that ratio in mind rather than in the
-    /// expectation that time scales with it.
+    /// and the second relationship is superlinear, so raise it with the measured
+    /// ratios below in mind rather than in the expectation that time scales with
+    /// it.
+    ///
+    /// A factorial is a loop of `n` bignum multiplications, so quadrupling this
+    /// budget costs roughly twelve times the worst-case factorial time: at the
+    /// 1 Mibit default the largest factorial admitted is `71421!`, about 0.43 s
+    /// in a release build. That is no longer the worst case, though. A base of
+    /// magnitude 1 short-circuits the power prediction — `1^n` is `1` under any
+    /// limit — so it goes on to run a repeated-squaring loop over every bit of
+    /// `n`, and `n` is bounded only by this budget applied to the literal. At
+    /// the default the largest such exponent is 315,652 digits, and evaluating
+    /// it takes about 1.57 s.
     pub max_value_bits: u64,
 }
 

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -27,7 +27,7 @@ impl Default for Limits {
 
 /// The size of a value in bits: for a rational, numerator plus denominator.
 #[must_use]
-pub fn size_in_bits(value: &Number) -> u64 {
+pub(crate) fn size_in_bits(value: &Number) -> u64 {
     match value {
         Number::NaturalNumber(v) => v.bits(),
         Number::DecimalNumber(v) => v.numer().bits() + v.denom().bits(),
@@ -51,7 +51,7 @@ fn check_bits(bits: u128, limits: Limits, phrase: &str) -> anyhow::Result<()> {
 ///
 /// # Errors
 /// When the value exceeds `limits.max_value_bits`.
-pub fn check_size(value: &Number, limits: Limits) -> anyhow::Result<()> {
+pub(crate) fn check_size(value: &Number, limits: Limits) -> anyhow::Result<()> {
     check_bits(u128::from(size_in_bits(value)), limits, "occupies")
 }
 
@@ -59,7 +59,7 @@ pub fn check_size(value: &Number, limits: Limits) -> anyhow::Result<()> {
 ///
 /// # Errors
 /// When `predicted_bits` exceeds `limits.max_value_bits`.
-pub fn check_predicted_size(predicted_bits: u128, limits: Limits) -> anyhow::Result<()> {
+pub(crate) fn check_predicted_size(predicted_bits: u128, limits: Limits) -> anyhow::Result<()> {
     check_bits(predicted_bits, limits, "would need")
 }
 
@@ -84,7 +84,7 @@ pub fn check_predicted_size(predicted_bits: u128, limits: Limits) -> anyhow::Res
 #[must_use]
 #[allow(clippy::cast_precision_loss)]
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-pub fn predicted_factorial_bits(n: u64) -> u128 {
+pub(crate) fn predicted_factorial_bits(n: u64) -> u128 {
     if n < 2 {
         return 1;
     }
@@ -121,7 +121,7 @@ pub fn predicted_factorial_bits(n: u64) -> u128 {
 /// direction to err in, and the discrepancy only matters within a factor of two of
 /// the budget.
 #[must_use]
-pub fn predicted_power_bits(base: &Number, exponent_magnitude: &BigUint) -> Option<u128> {
+pub(crate) fn predicted_power_bits(base: &Number, exponent_magnitude: &BigUint) -> Option<u128> {
     let base_bits = size_in_bits(base);
     if base_bits <= 1 {
         return Some(1);

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -6,6 +6,8 @@
 
 use crate::token::Number;
 use anyhow::anyhow;
+use num_bigint::BigUint;
+use num_traits::ToPrimitive;
 
 /// Resource bounds applied while evaluating an expression.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -97,7 +99,8 @@ pub fn predicted_factorial_bits(n: u64) -> u128 {
     bits.max(1.0).ceil() as u128
 }
 
-/// An upper bound on the bit length of `base^exponent` for an integral exponent.
+/// An upper bound on the bit length of `base^exponent` for an integral exponent,
+/// or [`None`] when the exponent is too large for the prediction to be made at all.
 ///
 /// Degenerate bases are special-cased first: when `base`'s magnitude is 0 or 1, so
 /// is the magnitude of any power of it, regardless of how large the exponent is, so
@@ -106,18 +109,24 @@ pub fn predicted_factorial_bits(n: u64) -> u128 {
 /// computation that is actually free — `1^10000000` is `1`, computed instantly — into
 /// one refused for needing ten million bits.
 ///
+/// That test deliberately comes *before* the exponent is narrowed to a `u64`, which
+/// is why the narrowing lives here rather than at the call site: an exponent too
+/// large to narrow is still irrelevant to a base of magnitude 1, and answering
+/// [`None`] for it would make the caller report an exponent as unevaluable when
+/// `1^n` is `1` under every conceivable limit.
+///
 /// For every other base it uses `bits(base)` where `log2(base)` would be exact, so
 /// it overestimates by up to a factor of two for small bases — `2^100` is predicted
 /// at 200 bits and occupies 101. A guard that errs toward refusing is the right
 /// direction to err in, and the discrepancy only matters within a factor of two of
 /// the budget.
 #[must_use]
-pub fn predicted_power_bits(base: &Number, exponent_magnitude: u64) -> u128 {
+pub fn predicted_power_bits(base: &Number, exponent_magnitude: &BigUint) -> Option<u128> {
     let base_bits = size_in_bits(base);
     if base_bits <= 1 {
-        return 1;
+        return Some(1);
     }
-    u128::from(base_bits) * u128::from(exponent_magnitude)
+    Some(u128::from(base_bits) * u128::from(exponent_magnitude.to_u64()?))
 }
 
 #[cfg(test)]
@@ -145,7 +154,10 @@ mod tests {
     #[test]
     fn test_power_prediction_multiplies_base_size_by_exponent() {
         let ten = Number::NaturalNumber(BigInt::from(10));
-        assert_eq!(predicted_power_bits(&ten, 100), 400);
+        assert_eq!(
+            predicted_power_bits(&ten, &BigUint::from(100_u32)),
+            Some(400)
+        );
     }
 
     #[test]
@@ -153,13 +165,29 @@ mod tests {
         // 1^n, 0^n and (-1)^n all have magnitude 0 or 1 no matter how large n is,
         // so a huge exponent must not inflate the prediction: base_bits.max(1) *
         // exponent_magnitude would otherwise turn a free computation into a refusal.
+        // The second exponent does not fit in a u64, which pins down that the
+        // degenerate test runs before the narrowing rather than after it.
+        let beyond_u64 = BigUint::from(u64::MAX) + BigUint::from(1_u32);
         for base in [
             Number::NaturalNumber(BigInt::from(1)),
             Number::NaturalNumber(BigInt::from(0)),
             Number::NaturalNumber(BigInt::from(-1)),
         ] {
-            assert_eq!(predicted_power_bits(&base, 10_000_000), 1);
+            assert_eq!(
+                predicted_power_bits(&base, &BigUint::from(10_000_000_u32)),
+                Some(1)
+            );
+            assert_eq!(predicted_power_bits(&base, &beyond_u64), Some(1));
         }
+    }
+
+    #[test]
+    fn test_power_prediction_declines_an_exponent_that_does_not_fit() {
+        // A base that actually grows plus an exponent beyond u64 has no usable
+        // prediction: the caller must refuse rather than guess.
+        let two = Number::NaturalNumber(BigInt::from(2));
+        let beyond_u64 = BigUint::from(u64::MAX) + BigUint::from(1_u32);
+        assert_eq!(predicted_power_bits(&two, &beyond_u64), None);
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,3 +1,4 @@
+use crate::rpn_resolver::MALFORMED_ERR;
 use crate::token::{self, Operator, Token};
 
 use anyhow::{anyhow, Result};
@@ -26,18 +27,14 @@ impl Parser {
 
         for m in EXPRESSION_REGEX.find_iter(expr) {
             Self::validate_gap(expr, cursor, m.start())?;
-            vex.push(Token::tokenize(m.as_str()).ok_or_else(|| {
-                anyhow!("Runtime Error: The mathematical expression is malformed.")
-            })?);
+            vex.push(Token::tokenize(m.as_str()).ok_or_else(|| anyhow!(MALFORMED_ERR))?);
             cursor = m.end();
         }
 
         Self::validate_gap(expr, cursor, expr.len())?;
 
         if vex.is_empty() {
-            return Err(anyhow!(
-                "Runtime Error: The mathematical expression is malformed."
-            ));
+            return Err(anyhow!(MALFORMED_ERR));
         }
 
         Ok(Self::mod_unary_operators(&vex))

--- a/src/rpn_resolver.rs
+++ b/src/rpn_resolver.rs
@@ -418,11 +418,20 @@ impl RpnResolver<'_> {
                     // not an operator or a function, and the `SemiColon` arm
                     // refuses a non-empty `bracket_stack` before it drains.
                     // Popping a frame above therefore guarantees a matching open
-                    // bracket is still below us here.
-                    debug_assert!(
-                        found_open,
-                        "a popped bracket frame must have a matching '(' in the operator stack"
-                    );
+                    // bracket is still below us here, so this branch is
+                    // unreachable and no test can cover it. It stays anyway,
+                    // because the loop above has by then drained the operator
+                    // stack into the output in exactly the order the normal
+                    // end-of-expression drain uses: the postfix sequence is still
+                    // evaluable, so falling through would not raise an error, it
+                    // would return a number computed with the bracket grouping
+                    // dissolved — `2*(3+4)` as `2 3 * 4 +`, which is 10 rather
+                    // than 14. Note also that the last clause above is doing real
+                    // work: the `SemiColon` guard is what keeps the two stacks in
+                    // step, and relaxing it makes this reachable again.
+                    if !found_open {
+                        return Err(anyhow!(MALFORMED_ERR));
+                    }
                 }
 
                 Token::Comma => {
@@ -454,11 +463,15 @@ impl RpnResolver<'_> {
                     // reached here through `bracket_stack.last_mut()` having
                     // yielded a frame: an enclosing frame exists, so its open
                     // bracket is still on `operators_stack`. This arm only peeks
-                    // at that bracket, so it also leaves the two in step.
-                    debug_assert!(
-                        found_open,
-                        "a comma inside a bracket frame must find that frame's '(' in the operator stack"
-                    );
+                    // at that bracket, so it also leaves the two in step. Also
+                    // unreachable, and kept for the same reason: the loop above
+                    // has already moved the operators into the output, so falling
+                    // through would silently mis-group the arguments rather than
+                    // fail, and the invariant it relies on rests on the
+                    // `SemiColon` guard staying where it is.
+                    if !found_open {
+                        return Err(anyhow!(MALFORMED_ERR));
+                    }
                 }
 
                 Token::SemiColon => {

--- a/src/rpn_resolver.rs
+++ b/src/rpn_resolver.rs
@@ -1,4 +1,5 @@
 use crate::functions::{decimal_from_f64, number_to_f64};
+use crate::limits::{self, Limits};
 use crate::{
     functions,
     parser::Parser,
@@ -43,6 +44,7 @@ pub struct RpnResolver<'a> {
     rpn_expr: VecDeque<Token<'a>>,
     local_heap: Rc<RefCell<HashMap<String, Number>>>,
     build_error: Option<String>,
+    limits: Limits,
 }
 
 impl RpnResolver<'_> {
@@ -51,6 +53,7 @@ impl RpnResolver<'_> {
     pub fn parse_with_borrowed_heap<'a>(
         exp: &'a str,
         borrowed_heap: Rc<RefCell<HashMap<String, Number>>>,
+        limits: Limits,
     ) -> RpnResolver<'a> {
         let heap_for_parse = Rc::clone(&borrowed_heap);
         match Parser::parse(exp).and_then(|tokenised_expr| {
@@ -60,11 +63,13 @@ impl RpnResolver<'_> {
                 rpn_expr,
                 local_heap,
                 build_error: None,
+                limits,
             },
             Err(err) => RpnResolver {
                 rpn_expr: VecDeque::new(),
                 local_heap: borrowed_heap,
                 build_error: Some(err.to_string()),
+                limits,
             },
         }
     }
@@ -78,6 +83,7 @@ impl RpnResolver<'_> {
 
         let zero: Number = Number::NaturalNumber(Zero::zero());
         let minus_one: Number = Number::NaturalNumber(BigInt::from(-1));
+        let limits = self.limits;
 
         let mut result_stack: VecDeque<Number> = VecDeque::new();
         let mut var_stack: VecDeque<Option<String>> = VecDeque::new();
@@ -111,26 +117,34 @@ impl RpnResolver<'_> {
 
                     match op {
                         Operator::Add => {
-                            result_stack.push_back(left_value + right_value);
+                            let value = left_value + right_value;
+                            limits::check_size(&value, limits)?;
+                            result_stack.push_back(value);
                             var_stack.push_back(None);
                         }
                         Operator::Sub => {
-                            result_stack.push_back(left_value - right_value);
+                            let value = left_value - right_value;
+                            limits::check_size(&value, limits)?;
+                            result_stack.push_back(value);
                             var_stack.push_back(None);
                         }
                         Operator::Mul => {
-                            result_stack.push_back(left_value * right_value);
+                            let value = left_value * right_value;
+                            limits::check_size(&value, limits)?;
+                            result_stack.push_back(value);
                             var_stack.push_back(None);
                         }
                         Operator::Div => {
                             if right_value == zero {
                                 return Err(anyhow!(DIVISION_ZERO_ERR));
                             }
-                            result_stack.push_back(left_value / right_value);
+                            let value = left_value / right_value;
+                            limits::check_size(&value, limits)?;
+                            result_stack.push_back(value);
                             var_stack.push_back(None);
                         }
                         Operator::Pow => {
-                            result_stack.push_back(Self::power(left_value, right_value)?);
+                            result_stack.push_back(Self::power(left_value, right_value, limits)?);
                             var_stack.push_back(None);
                         }
                         Operator::Eql => {
@@ -160,6 +174,10 @@ impl RpnResolver<'_> {
                             let n = n.to_u64().ok_or_else(|| {
                                 anyhow!("Runtime Error: Factorial operand is too large")
                             })?;
+                            limits::check_predicted_size(
+                                limits::predicted_factorial_bits(n),
+                                limits,
+                            )?;
                             let res = Self::factorial_helper(n.into());
                             result_stack.push_back(Number::NaturalNumber(res.into()));
                             var_stack.push_back(None);
@@ -382,9 +400,9 @@ impl RpnResolver<'_> {
         acc
     }
 
-    fn power(left_value: Number, right_value: Number) -> anyhow::Result<Number> {
+    fn power(left_value: Number, right_value: Number, limits: Limits) -> anyhow::Result<Number> {
         if let Some(exponent) = right_value.as_integer() {
-            return Self::power_integer(left_value, exponent);
+            return Self::power_integer(left_value, exponent, limits);
         }
 
         let base = number_to_f64(&left_value, POWER_TOO_LARGE_ERR)?;
@@ -392,7 +410,7 @@ impl RpnResolver<'_> {
         decimal_from_f64(base.powf(exponent), INVALID_POWER_ERR)
     }
 
-    fn power_integer(base: Number, exponent: BigInt) -> anyhow::Result<Number> {
+    fn power_integer(base: Number, exponent: BigInt, limits: Limits) -> anyhow::Result<Number> {
         if exponent.is_zero() {
             return Ok(Number::NaturalNumber(BigInt::one()));
         }
@@ -402,6 +420,14 @@ impl RpnResolver<'_> {
         let exponent = magnitude
             .to_biguint()
             .ok_or_else(|| anyhow!(INVALID_POWER_ERR))?;
+
+        let exponent_magnitude = exponent
+            .to_u64()
+            .ok_or_else(|| anyhow!(INVALID_POWER_ERR))?;
+        limits::check_predicted_size(
+            limits::predicted_power_bits(&base, exponent_magnitude),
+            limits,
+        )?;
 
         match base {
             Number::NaturalNumber(base) => {
@@ -534,6 +560,7 @@ mod tests {
             ]),
             local_heap: Rc::new(RefCell::new(HashMap::new())),
             build_error: None,
+            limits: Limits::default(),
         };
         assert_eq!(
             resolver.resolve().unwrap(),

--- a/src/rpn_resolver.rs
+++ b/src/rpn_resolver.rs
@@ -244,10 +244,17 @@ impl RpnResolver<'_> {
                     let var_name = v.to_lowercase();
                     debug!("Heap {:?}", self.local_heap);
                     let heap = self.local_heap.borrow();
+                    // An undefined variable reads as zero, deliberately.
                     let n = heap
                         .get(&var_name)
                         .cloned()
                         .unwrap_or_else(|| Number::NaturalNumber(BigInt::zero()));
+                    // Same reasoning as the operand arm above: a variable is a
+                    // value on the stack like any other. `set`/`setf` put values
+                    // into the heap without passing through any checked operator,
+                    // so without this an expression that only reads a variable
+                    // returns it however large it is.
+                    limits::check_size(&n, limits)?;
                     result_stack.push_back(n);
                     var_stack.push_back(Some(var_name));
                 }
@@ -401,9 +408,21 @@ impl RpnResolver<'_> {
                             _ => postfix_stack.push_back(token),
                         }
                     }
-                    if !found_open {
-                        return Err(anyhow!(MALFORMED_ERR));
-                    }
+                    // `bracket_stack` and `operators_stack` gain and lose open
+                    // brackets together: the `Bracket(Open)` arm pushes to both
+                    // with nothing between them that can fail, this arm is the
+                    // only one that removes an open bracket from
+                    // `operators_stack` and it removes exactly one per frame
+                    // popped, the `Comma` arm stops at an open bracket without
+                    // popping it, the `Operator` arm breaks on anything that is
+                    // not an operator or a function, and the `SemiColon` arm
+                    // refuses a non-empty `bracket_stack` before it drains.
+                    // Popping a frame above therefore guarantees a matching open
+                    // bracket is still below us here.
+                    debug_assert!(
+                        found_open,
+                        "a popped bracket frame must have a matching '(' in the operator stack"
+                    );
                 }
 
                 Token::Comma => {
@@ -431,9 +450,15 @@ impl RpnResolver<'_> {
                         postfix_stack
                             .push_back(operators_stack.pop().expect("It should not happen."));
                     }
-                    if !found_open {
-                        return Err(anyhow!(MALFORMED_ERR));
-                    }
+                    // Same lockstep invariant as the closing-bracket arm above,
+                    // reached here through `bracket_stack.last_mut()` having
+                    // yielded a frame: an enclosing frame exists, so its open
+                    // bracket is still on `operators_stack`. This arm only peeks
+                    // at that bracket, so it also leaves the two in step.
+                    debug_assert!(
+                        found_open,
+                        "a comma inside a bracket frame must find that frame's '(' in the operator stack"
+                    );
                 }
 
                 Token::SemiColon => {

--- a/src/rpn_resolver.rs
+++ b/src/rpn_resolver.rs
@@ -225,12 +225,20 @@ impl RpnResolver<'_> {
                             let n = n.to_u64().ok_or_else(|| {
                                 anyhow!("Runtime Error: Factorial operand is too large")
                             })?;
+                            // Predict first, to refuse `999999999!` in
+                            // milliseconds rather than computing it...
                             limits::check_predicted_size(
                                 limits::predicted_factorial_bits(n),
                                 limits,
                             )?;
                             let res = Self::factorial_helper(n.into());
-                            result_stack.push_back(Number::NaturalNumber(res.into()));
+                            // ...then measure what was actually built, because
+                            // the prediction is an asymptotic series rounded up
+                            // and is a bit short of the truth at `n = 2`. The
+                            // prediction buys the speed; this buys the exactness.
+                            let value = Number::NaturalNumber(res.into());
+                            limits::check_size(&value, limits)?;
+                            result_stack.push_back(value);
                             var_stack.push_back(None);
                         }
                         Operator::Une => {
@@ -585,13 +593,24 @@ impl RpnResolver<'_> {
     }
 
     fn power(left_value: Number, right_value: Number, limits: Limits) -> anyhow::Result<Number> {
-        if let Some(exponent) = right_value.as_integer() {
-            return Self::power_integer(left_value, exponent, limits);
-        }
+        let value = if let Some(exponent) = right_value.as_integer() {
+            Self::power_integer(left_value, exponent, limits)?
+        } else {
+            let base = number_to_f64(&left_value, POWER_TOO_LARGE_ERR)?;
+            let exponent = number_to_f64(&right_value, POWER_TOO_LARGE_ERR)?;
+            decimal_from_f64(base.powf(exponent), INVALID_POWER_ERR)?
+        };
 
-        let base = number_to_f64(&left_value, POWER_TOO_LARGE_ERR)?;
-        let exponent = number_to_f64(&right_value, POWER_TOO_LARGE_ERR)?;
-        decimal_from_f64(base.powf(exponent), INVALID_POWER_ERR)
+        // The prediction inside `power_integer` is an optimisation: it buys the
+        // right to refuse `10^100000000` without computing it. It is not the
+        // guarantee, and on two counts it cannot be. It never runs on the `powf`
+        // path at all, and on the integer path it predicts the magnitude of
+        // `base^|exponent|` while a negative exponent returns the reciprocal,
+        // whose denominator `size_in_bits` also counts — `2^-1` predicts 2 bits
+        // and yields `1/2`, which measures 3. Measuring the value we actually
+        // built is what makes the budget exact, on every path.
+        limits::check_size(&value, limits)?;
+        Ok(value)
     }
 
     fn power_integer(base: Number, exponent: BigInt, limits: Limits) -> anyhow::Result<Number> {

--- a/src/rpn_resolver.rs
+++ b/src/rpn_resolver.rs
@@ -1,12 +1,13 @@
+use crate::functions::{decimal_from_f64, number_to_f64};
 use crate::{
+    functions,
     parser::Parser,
     session::Session,
-    token::{self, MathFunction, Number, Operator, Token},
+    token::{self, Number, Operator, Token},
 };
 use anyhow::anyhow;
 use log::debug;
-use num::{Integer, Signed};
-use statrs::distribution::{Continuous, ContinuousCDF, Normal};
+use num::Integer;
 use std::{
     cell::RefCell,
     collections::{HashMap, VecDeque},
@@ -18,15 +19,16 @@ use num::{BigInt, BigUint, One, Zero};
 use num_rational::BigRational;
 use num_traits::ToPrimitive;
 
-static MALFORMED_ERR: &str = "Runtime Error: The mathematical expression is malformed.";
+pub(crate) static MALFORMED_ERR: &str = "Runtime Error: The mathematical expression is malformed.";
 static DIVISION_ZERO_ERR: &str = "Runtime error: Divide by zero.";
 static NO_VARIABLE_ERR: &str = "Runtime error: No variable has been defined for assignment.";
 static FACTORIAL_NATURAL_ERR: &str =
     "Runtime error: Factorial is only defined for non-negative integers.";
 static BUILTIN_CONSTANT_ERR: &str = "Runtime error: Built-in constants are read-only.";
-static INVALID_FUNCTION_RESULT_ERR: &str = "Runtime error: Function result is not a real number.";
+pub(crate) static INVALID_FUNCTION_RESULT_ERR: &str =
+    "Runtime error: Function result is not a real number.";
 static INVALID_POWER_ERR: &str = "Runtime error: Invalid power operation.";
-static FLOAT_EVAL_TOO_LARGE_ERR: &str =
+pub(crate) static FLOAT_EVAL_TOO_LARGE_ERR: &str =
     "Runtime error: Operand is too large for floating-point evaluation.";
 static POWER_TOO_LARGE_ERR: &str =
     "Runtime error: Power operands are too large for non-integer evaluation.";
@@ -191,109 +193,7 @@ impl RpnResolver<'_> {
                     ))?;
                     var_stack.pop_back();
 
-                    let result = match fun {
-                        MathFunction::Sin => Self::decimal_from_f64(
-                            Self::number_to_f64(&value, FLOAT_EVAL_TOO_LARGE_ERR)?.sin(),
-                            INVALID_FUNCTION_RESULT_ERR,
-                        )?,
-                        MathFunction::Cos => Self::decimal_from_f64(
-                            Self::number_to_f64(&value, FLOAT_EVAL_TOO_LARGE_ERR)?.cos(),
-                            INVALID_FUNCTION_RESULT_ERR,
-                        )?,
-                        MathFunction::Tan => Self::decimal_from_f64(
-                            Self::number_to_f64(&value, FLOAT_EVAL_TOO_LARGE_ERR)?.tan(),
-                            INVALID_FUNCTION_RESULT_ERR,
-                        )?,
-                        MathFunction::ASin => Self::decimal_from_f64(
-                            Self::number_to_f64(&value, FLOAT_EVAL_TOO_LARGE_ERR)?.asin(),
-                            INVALID_FUNCTION_RESULT_ERR,
-                        )?,
-                        MathFunction::ACos => Self::decimal_from_f64(
-                            Self::number_to_f64(&value, FLOAT_EVAL_TOO_LARGE_ERR)?.acos(),
-                            INVALID_FUNCTION_RESULT_ERR,
-                        )?,
-                        MathFunction::ATan => Self::decimal_from_f64(
-                            Self::number_to_f64(&value, FLOAT_EVAL_TOO_LARGE_ERR)?.atan(),
-                            INVALID_FUNCTION_RESULT_ERR,
-                        )?,
-                        MathFunction::Ln => Self::decimal_from_f64(
-                            Self::number_to_f64(&value, FLOAT_EVAL_TOO_LARGE_ERR)?.ln(),
-                            INVALID_FUNCTION_RESULT_ERR,
-                        )?,
-                        MathFunction::Log => Self::decimal_from_f64(
-                            Self::number_to_f64(&value, FLOAT_EVAL_TOO_LARGE_ERR)?.log10(),
-                            INVALID_FUNCTION_RESULT_ERR,
-                        )?,
-                        MathFunction::Abs => Self::to_decimal_number(match value {
-                            Number::NaturalNumber(v) => Number::NaturalNumber(v.abs()),
-                            Number::DecimalNumber(v) => Number::DecimalNumber(v.abs()),
-                        }),
-                        MathFunction::Max => {
-                            let value2: Number = result_stack.pop_back().ok_or(anyhow!(
-                                "{} {}",
-                                MALFORMED_ERR,
-                                "Wrong number of parameters for function Max"
-                            ))?;
-                            var_stack.pop_back();
-                            Self::to_decimal_number(if value >= value2 { value } else { value2 })
-                        }
-                        MathFunction::Min => {
-                            let value2: Number = result_stack.pop_back().ok_or(anyhow!(
-                                "{} {}",
-                                MALFORMED_ERR,
-                                "Wrong number of parameters for function Min"
-                            ))?;
-                            var_stack.pop_back();
-                            Self::to_decimal_number(if value <= value2 { value } else { value2 })
-                        }
-                        MathFunction::Sqrt => Self::decimal_from_f64(
-                            Self::number_to_f64(&value, FLOAT_EVAL_TOO_LARGE_ERR)?.sqrt(),
-                            INVALID_FUNCTION_RESULT_ERR,
-                        )?,
-                        MathFunction::Floor => {
-                            let value = Self::number_to_rational(value);
-                            Self::to_decimal_number(Number::NaturalNumber(
-                                value.numer().div_floor(value.denom()),
-                            ))
-                        }
-                        MathFunction::Ceil => {
-                            let value = Self::number_to_rational(value);
-                            Self::to_decimal_number(Number::NaturalNumber(
-                                value.numer().div_ceil(value.denom()),
-                            ))
-                        }
-                        MathFunction::Round => {
-                            let value = Self::number_to_rational(value);
-                            let denom = value.denom().clone();
-                            let doubled_numer = value.numer().clone() * BigInt::from(2_u8);
-                            let doubled_denom = denom.clone() * BigInt::from(2_u8);
-                            let rounded = if doubled_numer >= BigInt::zero() {
-                                (doubled_numer + denom).div_floor(&doubled_denom)
-                            } else {
-                                (doubled_numer - denom).div_ceil(&doubled_denom)
-                            };
-                            Self::to_decimal_number(Number::NaturalNumber(rounded))
-                        }
-                        MathFunction::Pdf => {
-                            let normal = Normal::new(0.0, 1.0).expect("valid normal dist");
-                            Self::decimal_from_f64(
-                                normal.pdf(Self::number_to_f64(&value, FLOAT_EVAL_TOO_LARGE_ERR)?),
-                                INVALID_FUNCTION_RESULT_ERR,
-                            )?
-                        }
-                        MathFunction::Cdf => {
-                            let normal = Normal::new(0.0, 1.0).expect("valid normal dist");
-                            Self::decimal_from_f64(
-                                normal.cdf(Self::number_to_f64(&value, FLOAT_EVAL_TOO_LARGE_ERR)?),
-                                INVALID_FUNCTION_RESULT_ERR,
-                            )?
-                        }
-                        MathFunction::Exp => Self::decimal_from_f64(
-                            Self::number_to_f64(&value, FLOAT_EVAL_TOO_LARGE_ERR)?.exp(),
-                            INVALID_FUNCTION_RESULT_ERR,
-                        )?,
-                        MathFunction::None => return Err(anyhow!("This should never happen!")),
-                    };
+                    let result = functions::eval(*fun, value, &mut result_stack, &mut var_stack)?;
                     result_stack.push_back(result);
                     var_stack.push_back(None);
                 }
@@ -485,37 +385,6 @@ impl RpnResolver<'_> {
         acc
     }
 
-    fn number_to_f64(value: &Number, error_message: &'static str) -> anyhow::Result<f64> {
-        match value {
-            Number::NaturalNumber(v) => v.to_f64().ok_or_else(|| anyhow!(error_message)),
-            Number::DecimalNumber(v) => v.to_f64().ok_or_else(|| anyhow!(error_message)),
-        }
-    }
-
-    fn decimal_from_f64(value: f64, error_message: &'static str) -> anyhow::Result<Number> {
-        if !value.is_finite() {
-            return Err(anyhow!(error_message));
-        }
-
-        BigRational::from_float(value)
-            .map(Number::DecimalNumber)
-            .ok_or_else(|| anyhow!(error_message))
-    }
-
-    fn number_to_rational(value: Number) -> BigRational {
-        match value {
-            Number::NaturalNumber(v) => BigRational::from_integer(v),
-            Number::DecimalNumber(v) => v,
-        }
-    }
-
-    fn to_decimal_number(value: Number) -> Number {
-        match value {
-            Number::NaturalNumber(v) => Number::DecimalNumber(BigRational::from_integer(v)),
-            Number::DecimalNumber(v) => Number::DecimalNumber(v),
-        }
-    }
-
     fn integer_exponent(value: &Number) -> Option<BigInt> {
         match value {
             Number::NaturalNumber(v) => Some(v.clone()),
@@ -529,9 +398,9 @@ impl RpnResolver<'_> {
             return Self::power_integer(left_value, exponent);
         }
 
-        let base = Self::number_to_f64(&left_value, POWER_TOO_LARGE_ERR)?;
-        let exponent = Self::number_to_f64(&right_value, POWER_TOO_LARGE_ERR)?;
-        Self::decimal_from_f64(base.powf(exponent), INVALID_POWER_ERR)
+        let base = number_to_f64(&left_value, POWER_TOO_LARGE_ERR)?;
+        let exponent = number_to_f64(&right_value, POWER_TOO_LARGE_ERR)?;
+        decimal_from_f64(base.powf(exponent), INVALID_POWER_ERR)
     }
 
     fn power_integer(base: Number, exponent: BigInt) -> anyhow::Result<Number> {

--- a/src/rpn_resolver.rs
+++ b/src/rpn_resolver.rs
@@ -723,25 +723,22 @@ mod tests {
         assert!(resolver2.resolve().is_err());
     }
 
+    /// `max` and `min` of integers return integers, and the enum tag has to say
+    /// so. Asserting the value alone is not enough: cross-variant equality makes
+    /// `NaturalNumber(2) == DecimalNumber(2/1)`, so a value-only assertion passes
+    /// whichever variant comes back. That is exactly how this test used to read
+    /// as "max returns a decimal" and stay green under either behaviour.
     #[test]
     fn test_max_min() {
         let session = Session::init();
-        let mut resolver = session.process("max(1,2)");
-        assert_eq!(
-            resolver.resolve().unwrap(),
-            Number::DecimalNumber(BigRational::from_float(2.0).unwrap())
-        );
-
-        let mut resolver = session.process("min(1,2)");
-        assert_eq!(
-            resolver.resolve().unwrap(),
-            Number::DecimalNumber(BigRational::from_float(1.0).unwrap())
-        );
-
-        let mut resolver = session.process("min(max(1,2),3)");
-        assert_eq!(
-            resolver.resolve().unwrap(),
-            Number::DecimalNumber(BigRational::from_float(2.0).unwrap())
-        );
+        for (expr, expected) in [("max(1,2)", 2), ("min(1,2)", 1), ("min(max(1,2),3)", 2)] {
+            let mut resolver = session.process(expr);
+            let result = resolver.resolve().unwrap();
+            assert_eq!(result, Number::NaturalNumber(BigInt::from(expected)));
+            assert!(
+                matches!(result, Number::NaturalNumber(_)),
+                "{expr} produced {result:?}, expected a NaturalNumber"
+            );
+        }
     }
 }

--- a/src/rpn_resolver.rs
+++ b/src/rpn_resolver.rs
@@ -138,6 +138,11 @@ impl RpnResolver<'_> {
         for t in &self.rpn_expr {
             match t {
                 Token::Operand(n) => {
+                    // The budget is documented as bounding every intermediate and
+                    // final result, so it has to hold for a value that arrives as a
+                    // literal too — otherwise a long enough literal is returned
+                    // above the limit the caller asked for.
+                    limits::check_size(n, limits)?;
                     result_stack.push_back(n.clone());
                     var_stack.push_back(None);
                 }
@@ -496,6 +501,14 @@ impl RpnResolver<'_> {
             return Err(function_requires_parentheses_err(fun));
         }
 
+        // A frame still on the stack is a bracket that was opened and never
+        // closed. That is the same condition class as a stray closing bracket,
+        // so it gets the same named diagnosis rather than falling through to the
+        // generic malformed-expression message below.
+        if !bracket_stack.is_empty() {
+            return Err(anyhow!(UNBALANCED_BRACKET_ERR));
+        }
+
         /* After all tokens are read, pop remaining operators from the stack and add them to the list. */
         operators_stack.reverse();
         for t in &operators_stack {
@@ -554,13 +567,13 @@ impl RpnResolver<'_> {
             .to_biguint()
             .ok_or_else(|| anyhow!(INVALID_POWER_ERR))?;
 
-        let exponent_magnitude = exponent
-            .to_u64()
+        // A degenerate base short-circuits inside the prediction, before the
+        // exponent's own magnitude is ever consulted, so `1^n` stays evaluable for
+        // an `n` no `u64` could hold. Only a base that actually grows can make the
+        // exponent unrepresentable, and that is the one case this message fits.
+        let predicted_bits = limits::predicted_power_bits(&base, &exponent)
             .ok_or_else(|| anyhow!(EXPONENT_TOO_LARGE_ERR))?;
-        limits::check_predicted_size(
-            limits::predicted_power_bits(&base, exponent_magnitude),
-            limits,
-        )?;
+        limits::check_predicted_size(predicted_bits, limits)?;
 
         match base {
             Number::NaturalNumber(base) => {

--- a/src/rpn_resolver.rs
+++ b/src/rpn_resolver.rs
@@ -275,6 +275,14 @@ impl RpnResolver<'_> {
                     var_stack.pop_back();
 
                     let result = functions::eval(*fun, value, &mut result_stack, &mut var_stack)?;
+                    // Every arm that pushes a value checks it. A function result
+                    // is bounded by construction — the built-ins all route
+                    // through `f64` — but "bounded" is not "checked", and the
+                    // difference is not academic: an unchecked value goes on to
+                    // feed guards that assume their input was checked, which is
+                    // how `floor(exp(1))!` slipped a 2-bit result past a 1-bit
+                    // budget through the factorial's predictive guard.
+                    limits::check_size(&result, limits)?;
                     result_stack.push_back(result);
                     var_stack.push_back(None);
                 }

--- a/src/rpn_resolver.rs
+++ b/src/rpn_resolver.rs
@@ -38,6 +38,9 @@ static EXPONENT_TOO_LARGE_ERR: &str =
 static COMMA_OUTSIDE_CALL_ERR: &str =
     "Parse Error: ',' is only valid between the arguments of a function call.";
 static UNBALANCED_BRACKET_ERR: &str = "Parse Error: Unbalanced brackets.";
+static EMPTY_ARGUMENT_ERR: &str = "Parse Error: A function argument cannot be empty.";
+static BRACKET_UNCLOSED_AT_SEMICOLON_ERR: &str =
+    "Parse Error: A bracket must be closed before ';'.";
 
 /// The main [`RpnResolver`] contains the core logic of Yarer
 /// for parsing and evaluating a math expression.
@@ -56,13 +59,20 @@ pub struct RpnResolver<'a> {
 /// call and how many arguments it has seen so far.
 struct BracketFrame {
     function: Option<MathFunction>,
+    /// Number of `,` separators seen so far in this bracket.
     commas: usize,
+    /// Whether the *current* argument slot — since the bracket opened, or
+    /// since the last `,` — has seen any content. Reset after each `,` so an
+    /// empty slot (`max(,1)`, `max(1,)`) is caught exactly where it occurs,
+    /// rather than being silently absorbed into the overall argument count.
     has_content: bool,
 }
 
 impl BracketFrame {
     /// An empty pair of brackets carries zero arguments; otherwise there is one
-    /// more argument than there are separators.
+    /// more argument than there are separators. This is only accurate once
+    /// every slot has been confirmed non-empty, which the caller enforces at
+    /// each `,` and at the closing bracket before trusting this count.
     fn argument_count(&self) -> usize {
         if self.has_content {
             self.commas + 1
@@ -70,6 +80,17 @@ impl BracketFrame {
             0
         }
     }
+}
+
+/// The error reported when a function name is not immediately followed by an
+/// opening bracket. Built in one place because the check itself runs at two
+/// points: mid-scan, against whatever token follows the function name, and
+/// once more at end of input, for a function name with nothing after it at all.
+fn function_requires_parentheses_err(fun: MathFunction) -> anyhow::Error {
+    anyhow!(
+        "Parse Error: Function '{}' must be followed by '('.",
+        fun.to_string().to_lowercase()
+    )
 }
 
 impl RpnResolver<'_> {
@@ -294,14 +315,16 @@ impl RpnResolver<'_> {
         for t in infix_stack {
             if let Some(fun) = pending_function {
                 if !matches!(t, Token::Bracket(token::Bracket::Open)) {
-                    return Err(anyhow!(
-                        "Parse Error: Function '{}' must be followed by '('.",
-                        fun.to_string().to_lowercase()
-                    ));
+                    return Err(function_requires_parentheses_err(fun));
                 }
             }
 
-            if !matches!(t, Token::Comma | Token::Bracket(token::Bracket::Close)) {
+            // Both brackets are excluded here: an opening bracket has not yet
+            // proven it contributes a value (the group it opens might turn out
+            // empty, e.g. the inner `()` in `sin(())`), so marking is deferred
+            // to the moment its matching close confirms the group was non-empty.
+            // See the `Token::Bracket(Close)` arm below.
+            if !matches!(t, Token::Comma | Token::Bracket(_)) {
                 if let Some(frame) = bracket_stack.last_mut() {
                     frame.has_content = true;
                 }
@@ -328,6 +351,12 @@ impl RpnResolver<'_> {
                     let frame = bracket_stack
                         .pop()
                         .ok_or_else(|| anyhow!(UNBALANCED_BRACKET_ERR))?;
+                    // A trailing separator (`max(1,)`) leaves the final slot
+                    // empty; catch it here rather than letting it silently
+                    // shrink the argument count by one.
+                    if frame.commas > 0 && !frame.has_content {
+                        return Err(anyhow!(EMPTY_ARGUMENT_ERR));
+                    }
                     if let Some(fun) = frame.function {
                         let given = frame.argument_count();
                         let expected = usize::from(fun.arity());
@@ -338,6 +367,16 @@ impl RpnResolver<'_> {
                                 expected,
                                 given
                             ));
+                        }
+                    }
+                    // This bracket produced a value: let the enclosing slot (if
+                    // any) know, now that the group is confirmed non-empty
+                    // rather than merely opened. An empty group like the inner
+                    // `()` in `sin(())` must not count as content for the slot
+                    // that contains it.
+                    if frame.has_content {
+                        if let Some(outer) = bracket_stack.last_mut() {
+                            outer.has_content = true;
                         }
                     }
 
@@ -369,7 +408,14 @@ impl RpnResolver<'_> {
                     if frame.function.is_none() {
                         return Err(anyhow!(COMMA_OUTSIDE_CALL_ERR));
                     }
+                    // The slot that ends here (since the open bracket or the
+                    // previous ',') must not be empty, e.g. the first slot in
+                    // `max(,1)`.
+                    if !frame.has_content {
+                        return Err(anyhow!(EMPTY_ARGUMENT_ERR));
+                    }
                     frame.commas += 1;
+                    frame.has_content = false; // a fresh slot starts now
 
                     let mut found_open = false;
                     while let Some(token) = operators_stack.last() {
@@ -386,6 +432,15 @@ impl RpnResolver<'_> {
                 }
 
                 Token::SemiColon => {
+                    // A bracket left open across a ';' is a parse error in its
+                    // own right: without this check the frame just lingers
+                    // (out of sync with `operators_stack`, which the loop below
+                    // does drain), and the eventual mismatch on some later
+                    // close surfaces as a confusing arity error instead of
+                    // naming what's actually wrong.
+                    if !bracket_stack.is_empty() {
+                        return Err(anyhow!(BRACKET_UNCLOSED_AT_SEMICOLON_ERR));
+                    }
                     while let Some(token) = operators_stack.pop() {
                         postfix_stack.push_back(token);
                     }
@@ -438,10 +493,7 @@ impl RpnResolver<'_> {
         }
 
         if let Some(fun) = pending_function {
-            return Err(anyhow!(
-                "Parse Error: Function '{}' must be followed by '('.",
-                fun.to_string().to_lowercase()
-            ));
+            return Err(function_requires_parentheses_err(fun));
         }
 
         /* After all tokens are read, pop remaining operators from the stack and add them to the list. */

--- a/src/rpn_resolver.rs
+++ b/src/rpn_resolver.rs
@@ -33,6 +33,8 @@ pub(crate) static FLOAT_EVAL_TOO_LARGE_ERR: &str =
     "Runtime error: Operand is too large for floating-point evaluation.";
 static POWER_TOO_LARGE_ERR: &str =
     "Runtime error: Power operands are too large for non-integer evaluation.";
+static EXPONENT_TOO_LARGE_ERR: &str =
+    "Runtime error: the exponent is too large to evaluate under any size limit.";
 
 /// The main [`RpnResolver`] contains the core logic of Yarer
 /// for parsing and evaluating a math expression.
@@ -423,7 +425,7 @@ impl RpnResolver<'_> {
 
         let exponent_magnitude = exponent
             .to_u64()
-            .ok_or_else(|| anyhow!(INVALID_POWER_ERR))?;
+            .ok_or_else(|| anyhow!(EXPONENT_TOO_LARGE_ERR))?;
         limits::check_predicted_size(
             limits::predicted_power_bits(&base, exponent_magnitude),
             limits,

--- a/src/rpn_resolver.rs
+++ b/src/rpn_resolver.rs
@@ -4,7 +4,7 @@ use crate::{
     functions,
     parser::Parser,
     session::Session,
-    token::{self, Number, Operator, Token},
+    token::{self, MathFunction, Number, Operator, Token},
 };
 use anyhow::anyhow;
 use log::debug;
@@ -35,6 +35,9 @@ static POWER_TOO_LARGE_ERR: &str =
     "Runtime error: Power operands are too large for non-integer evaluation.";
 static EXPONENT_TOO_LARGE_ERR: &str =
     "Runtime error: the exponent is too large to evaluate under any size limit.";
+static COMMA_OUTSIDE_CALL_ERR: &str =
+    "Parse Error: ',' is only valid between the arguments of a function call.";
+static UNBALANCED_BRACKET_ERR: &str = "Parse Error: Unbalanced brackets.";
 
 /// The main [`RpnResolver`] contains the core logic of Yarer
 /// for parsing and evaluating a math expression.
@@ -47,6 +50,26 @@ pub struct RpnResolver<'a> {
     local_heap: Rc<RefCell<HashMap<String, Number>>>,
     build_error: Option<String>,
     limits: Limits,
+}
+
+/// One entry per open bracket, recording whether that bracket opens a function
+/// call and how many arguments it has seen so far.
+struct BracketFrame {
+    function: Option<MathFunction>,
+    commas: usize,
+    has_content: bool,
+}
+
+impl BracketFrame {
+    /// An empty pair of brackets carries zero arguments; otherwise there is one
+    /// more argument than there are separators.
+    fn argument_count(&self) -> usize {
+        if self.has_content {
+            self.commas + 1
+        } else {
+            0
+        }
+    }
 }
 
 impl RpnResolver<'_> {
@@ -264,20 +287,60 @@ impl RpnResolver<'_> {
         let mut operators_stack: Vec<Token> = Vec::new();
         let mut postfix_stack: VecDeque<Token> = VecDeque::new();
         let mut seen_variables: Vec<String> = Vec::new();
+        let mut bracket_stack: Vec<BracketFrame> = Vec::new();
+        let mut pending_function: Option<MathFunction> = None;
 
         /* Scan the infix expression from left to right. */
         for t in infix_stack {
+            if let Some(fun) = pending_function {
+                if !matches!(t, Token::Bracket(token::Bracket::Open)) {
+                    return Err(anyhow!(
+                        "Parse Error: Function '{}' must be followed by '('.",
+                        fun.to_string().to_lowercase()
+                    ));
+                }
+            }
+
+            if !matches!(t, Token::Comma | Token::Bracket(token::Bracket::Close)) {
+                if let Some(frame) = bracket_stack.last_mut() {
+                    frame.has_content = true;
+                }
+            }
+
             match *t {
                 /* If the token is an operand, add it to the output list. */
                 Token::Operand(_) => postfix_stack.push_back(t.clone()),
 
                 /* If the token is a left parenthesis, push it on the stack. */
-                Token::Bracket(token::Bracket::Open) => operators_stack.push(t.clone()),
+                Token::Bracket(token::Bracket::Open) => {
+                    bracket_stack.push(BracketFrame {
+                        function: pending_function.take(),
+                        commas: 0,
+                        has_content: false,
+                    });
+                    operators_stack.push(t.clone());
+                }
 
                 /* If the token is a right parenthesis:
                 Pop the stack and add operators to the output list until you encounter a left parenthesis.
                 Pop the left parenthesis from the stack but do not add it to the output list.*/
                 Token::Bracket(token::Bracket::Close) => {
+                    let frame = bracket_stack
+                        .pop()
+                        .ok_or_else(|| anyhow!(UNBALANCED_BRACKET_ERR))?;
+                    if let Some(fun) = frame.function {
+                        let given = frame.argument_count();
+                        let expected = usize::from(fun.arity());
+                        if given != expected {
+                            return Err(anyhow!(
+                                "Parse Error: Function '{}' expects {} argument(s), {} given.",
+                                fun.to_string().to_lowercase(),
+                                expected,
+                                given
+                            ));
+                        }
+                    }
+
                     let mut found_open = false;
                     while let Some(token) = operators_stack.pop() {
                         match token {
@@ -300,6 +363,14 @@ impl RpnResolver<'_> {
                 }
 
                 Token::Comma => {
+                    let frame = bracket_stack
+                        .last_mut()
+                        .ok_or_else(|| anyhow!(COMMA_OUTSIDE_CALL_ERR))?;
+                    if frame.function.is_none() {
+                        return Err(anyhow!(COMMA_OUTSIDE_CALL_ERR));
+                    }
+                    frame.commas += 1;
+
                     let mut found_open = false;
                     while let Some(token) = operators_stack.last() {
                         if matches!(token, Token::Bracket(token::Bracket::Open)) {
@@ -347,7 +418,8 @@ impl RpnResolver<'_> {
                     operators_stack.push(op1.clone());
                 }
 
-                Token::Function(_) => {
+                Token::Function(f) => {
+                    pending_function = Some(f);
                     operators_stack.push(t.clone());
                 }
 
@@ -363,6 +435,13 @@ impl RpnResolver<'_> {
                 DisplayThisDeque(&postfix_stack),
                 DisplayThatVec(&operators_stack)
             );
+        }
+
+        if let Some(fun) = pending_function {
+            return Err(anyhow!(
+                "Parse Error: Function '{}' must be followed by '('.",
+                fun.to_string().to_lowercase()
+            ));
         }
 
         /* After all tokens are read, pop remaining operators from the stack and add them to the list. */

--- a/src/rpn_resolver.rs
+++ b/src/rpn_resolver.rs
@@ -149,23 +149,20 @@ impl RpnResolver<'_> {
                             }
                         }
                         Operator::Fac => {
-                            // factorial. Only for non-negative integers
-                            match right_value {
-                                Number::NaturalNumber(v) => {
-                                    if v < Zero::zero() {
-                                        return Err(anyhow!(FACTORIAL_NATURAL_ERR));
-                                    }
-                                    let n = v.to_u64().ok_or_else(|| {
-                                        anyhow!("Runtime Error: Factorial operand is too large")
-                                    })?;
-                                    let res = Self::factorial_helper(n.into());
-                                    result_stack.push_back(Number::NaturalNumber(res.into()));
-                                    var_stack.push_back(None);
-                                }
-                                Number::DecimalNumber(_) => {
-                                    return Err(anyhow!(FACTORIAL_NATURAL_ERR));
-                                }
+                            // Factorial is defined on non-negative integers. It asks the
+                            // value, not the enum tag: floor(2.5) and 6/3 are integers.
+                            let n = right_value
+                                .as_integer()
+                                .ok_or_else(|| anyhow!(FACTORIAL_NATURAL_ERR))?;
+                            if n < BigInt::zero() {
+                                return Err(anyhow!(FACTORIAL_NATURAL_ERR));
                             }
+                            let n = n.to_u64().ok_or_else(|| {
+                                anyhow!("Runtime Error: Factorial operand is too large")
+                            })?;
+                            let res = Self::factorial_helper(n.into());
+                            result_stack.push_back(Number::NaturalNumber(res.into()));
+                            var_stack.push_back(None);
                         }
                         Operator::Une => {
                             //# unary neg
@@ -385,16 +382,8 @@ impl RpnResolver<'_> {
         acc
     }
 
-    fn integer_exponent(value: &Number) -> Option<BigInt> {
-        match value {
-            Number::NaturalNumber(v) => Some(v.clone()),
-            Number::DecimalNumber(v) if v.denom().is_one() => Some(v.to_integer()),
-            Number::DecimalNumber(_) => None,
-        }
-    }
-
     fn power(left_value: Number, right_value: Number) -> anyhow::Result<Number> {
-        if let Some(exponent) = Self::integer_exponent(&right_value) {
+        if let Some(exponent) = right_value.as_integer() {
             return Self::power_integer(left_value, exponent);
         }
 
@@ -422,10 +411,7 @@ impl RpnResolver<'_> {
                     }
 
                     let value = Self::pow_big_int(base, exponent);
-                    Ok(Number::DecimalNumber(BigRational::new(
-                        BigInt::one(),
-                        value,
-                    )))
+                    Ok(Number::decimal(BigRational::new(BigInt::one(), value)))
                 } else {
                     Ok(Number::NaturalNumber(Self::pow_big_int(base, exponent)))
                 }
@@ -437,9 +423,9 @@ impl RpnResolver<'_> {
 
                 let value = Self::pow_big_rational(base, exponent);
                 if is_negative {
-                    Ok(Number::DecimalNumber(value.recip()))
+                    Ok(Number::decimal(value.recip()))
                 } else {
-                    Ok(Number::DecimalNumber(value))
+                    Ok(Number::decimal(value))
                 }
             }
         }

--- a/src/session.rs
+++ b/src/session.rs
@@ -129,14 +129,19 @@ mod tests {
     use super::*;
     use crate::token::Number;
 
-    /// Test for the session initialization and basic expression processing
+    /// Asserts both the value and the variant. Cross-variant equality means a
+    /// value-only assertion cannot tell `NaturalNumber(-5)` from
+    /// `DecimalNumber(-5/1)`, so only the `matches!` makes this sensitive to the
+    /// canonicalisation invariant it is here to protect.
     #[test]
     fn test_session() {
         let session = Session::init();
         let mut resolver: RpnResolver = session.process("1+2*3/(4-5)");
-        assert_eq!(
-            resolver.resolve().unwrap(),
-            Number::DecimalNumber(num_rational::BigRational::from_float(-5.0).unwrap())
+        let result = resolver.resolve().unwrap();
+        assert_eq!(result, Number::NaturalNumber(BigInt::from(-5)));
+        assert!(
+            matches!(result, Number::NaturalNumber(_)),
+            "produced {result:?}, expected a NaturalNumber"
         );
     }
 
@@ -146,9 +151,11 @@ mod tests {
         let session = Session::init();
         session.set("x", 4);
         let mut resolver: RpnResolver = session.process("x+2*3/(4-5)");
-        assert_eq!(
-            resolver.resolve().unwrap(),
-            Number::DecimalNumber(num_rational::BigRational::from_float(-2.0).unwrap())
+        let result = resolver.resolve().unwrap();
+        assert_eq!(result, Number::NaturalNumber(BigInt::from(-2)));
+        assert!(
+            matches!(result, Number::NaturalNumber(_)),
+            "produced {result:?}, expected a NaturalNumber"
         );
     }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -34,6 +34,13 @@ impl Session {
     }
 
     /// Builds a session whose evaluations are bound by `limits`.
+    ///
+    /// The bound reaches the built-in constants too, and they are wider than
+    /// they look: `pi`, `e`, `tau`, `phi` and `gamma` are `f64`s held exactly as
+    /// rationals, costing numerator bits plus denominator bits — 99 for `pi`, and
+    /// 107 for `gamma`, the widest. A `max_value_bits` under 107 therefore
+    /// rejects a value the caller never supplied. A limit meant to bound
+    /// untrusted input should sit well above that.
     #[must_use]
     pub fn with_limits(limits: Limits) -> Session {
         Session {

--- a/src/session.rs
+++ b/src/session.rs
@@ -48,31 +48,25 @@ impl Session {
         let mut local_heap: HashMap<String, Number> = HashMap::new();
         local_heap.insert(
             "pi".to_string(),
-            Number::DecimalNumber(
-                num_rational::BigRational::from_float(std::f64::consts::PI).unwrap(),
-            ),
+            Number::decimal(num_rational::BigRational::from_float(std::f64::consts::PI).unwrap()),
         );
         local_heap.insert(
             "e".to_string(),
-            Number::DecimalNumber(
-                num_rational::BigRational::from_float(std::f64::consts::E).unwrap(),
-            ),
+            Number::decimal(num_rational::BigRational::from_float(std::f64::consts::E).unwrap()),
         );
         local_heap.insert(
             "tau".to_string(),
-            Number::DecimalNumber(
-                num_rational::BigRational::from_float(std::f64::consts::TAU).unwrap(),
-            ),
+            Number::decimal(num_rational::BigRational::from_float(std::f64::consts::TAU).unwrap()),
         );
         local_heap.insert(
             "phi".to_string(),
-            Number::DecimalNumber(
+            Number::decimal(
                 num_rational::BigRational::from_float((1.0 + 5.0f64.sqrt()) / 2.0).unwrap(),
             ),
         );
         local_heap.insert(
             "gamma".to_string(),
-            Number::DecimalNumber(
+            Number::decimal(
                 num_rational::BigRational::from_float(0.577_215_664_901_532_9_f64).unwrap(),
             ),
         );
@@ -117,7 +111,7 @@ impl Session {
         if let Some(value) = num_rational::BigRational::from_float(value) {
             self.variable_heap
                 .borrow_mut()
-                .insert(key, Number::DecimalNumber(value));
+                .insert(key, Number::decimal(value));
         }
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -103,7 +103,12 @@ impl Session {
             .insert(key, Number::NaturalNumber(BigInt::from(value)));
     }
 
-    /// Declares and saves a new float variable ([`Number::DecimalNumber`])
+    /// Declares and saves a new variable from an [`f64`].
+    ///
+    /// The value decides the representation, not the setter. The rational is
+    /// built through [`Number::decimal`], so an integral `f64` is stored as a
+    /// [`Number::NaturalNumber`] — `setf("x", 4.0)` stores `4` — and only a
+    /// genuinely fractional value is stored as a [`Number::DecimalNumber`].
     ///
     /// Example
     /// ``

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,3 +1,4 @@
+use crate::limits::Limits;
 use crate::{rpn_resolver::RpnResolver, token::Number};
 use num_bigint::BigInt;
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
@@ -9,6 +10,7 @@ use std::{cell::RefCell, collections::HashMap, rc::Rc};
 ///
 pub struct Session {
     variable_heap: Rc<RefCell<HashMap<String, Number>>>,
+    limits: Limits,
 }
 
 const BUILTIN_CONSTANTS: [&str; 5] = ["pi", "e", "tau", "phi", "gamma"];
@@ -28,9 +30,15 @@ impl Session {
     ///
     #[must_use]
     pub fn init() -> Session {
-        // let variable_heap: HashMap<String, Number> = ;
+        Session::with_limits(Limits::default())
+    }
+
+    /// Builds a session whose evaluations are bound by `limits`.
+    #[must_use]
+    pub fn with_limits(limits: Limits) -> Session {
         Session {
             variable_heap: Rc::new(RefCell::new(Session::init_local_heap())),
+            limits,
         }
     }
 
@@ -39,7 +47,7 @@ impl Session {
     #[must_use]
     pub fn process<'a>(&'a self, line: &'a str) -> RpnResolver<'a> {
         let clone = Rc::clone(&self.variable_heap); // clones the Rc pointer, not the whole heap!
-        RpnResolver::parse_with_borrowed_heap(line, clone)
+        RpnResolver::parse_with_borrowed_heap(line, clone, self.limits)
     }
 
     /// Creates a Variables heap (name-value)

--- a/src/token.rs
+++ b/src/token.rs
@@ -9,7 +9,7 @@ use std::{
 /// Enum Type [Number]. Either an BigInt integer [`Number::NaturalNumber`]
 /// or a [`BigRational`] rational number [`Number::DecimalNumber`]
 ///
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Clone)]
 pub enum Number {
     /// an Integer [BigInt]
     NaturalNumber(BigInt),
@@ -220,7 +220,7 @@ impl Token<'_> {
         }
 
         if let Some(v) = parse_decimal_literal(t) {
-            return Some(Token::Operand(Number::DecimalNumber(v)));
+            return Some(Token::Operand(Number::decimal(v)));
         }
 
         if let Some(fun) = Token::get_some(t) {
@@ -258,6 +258,56 @@ impl Token<'_> {
 
         v_op1.1 == Associate::LeftAssociative && v_op1.0 <= v_op2.0
             || v_op1.1 == Associate::RightAssociative && v_op1.0 < v_op2.0
+    }
+}
+
+impl Number {
+    /// Builds a decimal number, degrading to [`Number::NaturalNumber`] when the
+    /// rational turns out to be a whole number.
+    ///
+    /// This is the only sanctioned way to build a [`Number::DecimalNumber`]:
+    /// it upholds the invariant that a decimal never carries a denominator of 1,
+    /// so a given mathematical value has exactly one representation.
+    #[must_use]
+    pub fn decimal(value: BigRational) -> Number {
+        if value.denom().is_one() {
+            Number::NaturalNumber(value.to_integer())
+        } else {
+            Number::DecimalNumber(value)
+        }
+    }
+
+    /// Returns the integral value of this number, or [`None`] when it has a
+    /// fractional part.
+    ///
+    /// The decimal arm matters only for values built by hand from outside the
+    /// crate, which can bypass [`Number::decimal`]; internally the invariant
+    /// makes it unreachable.
+    #[must_use]
+    pub fn as_integer(&self) -> Option<BigInt> {
+        match self {
+            Number::NaturalNumber(v) => Some(v.clone()),
+            Number::DecimalNumber(v) if v.denom().is_one() => Some(v.to_integer()),
+            Number::DecimalNumber(_) => None,
+        }
+    }
+}
+
+/// Equality by mathematical value, so that it agrees with [`PartialOrd`].
+///
+/// The derived implementation compared enum variants, which made
+/// `NaturalNumber(2) == DecimalNumber(2/1)` false while `>=` reported true —
+/// a violation of the `PartialOrd` contract that generic code relies on.
+impl PartialEq for Number {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Number::NaturalNumber(a), Number::NaturalNumber(b)) => a == b,
+            (Number::DecimalNumber(a), Number::DecimalNumber(b)) => a == b,
+            (Number::NaturalNumber(a), Number::DecimalNumber(b))
+            | (Number::DecimalNumber(b), Number::NaturalNumber(a)) => {
+                BigRational::from(a.clone()) == *b
+            }
+        }
     }
 }
 
@@ -299,12 +349,12 @@ where
     match (ln, rn.clone()) {
         (Number::NaturalNumber(v1), Number::NaturalNumber(v2)) => Number::NaturalNumber(nf(v1, v2)),
         (Number::NaturalNumber(v1), Number::DecimalNumber(v2)) => {
-            Number::DecimalNumber(df(BigRational::from(v1), v2))
+            Number::decimal(df(BigRational::from(v1), v2))
         }
         (Number::DecimalNumber(v1), Number::NaturalNumber(v2)) => {
-            Number::DecimalNumber(df(v1, BigRational::from(v2)))
+            Number::decimal(df(v1, BigRational::from(v2)))
         }
-        (Number::DecimalNumber(v1), Number::DecimalNumber(v2)) => Number::DecimalNumber(df(v1, v2)),
+        (Number::DecimalNumber(v1), Number::DecimalNumber(v2)) => Number::decimal(df(v1, v2)),
     }
 }
 
@@ -338,17 +388,15 @@ impl Div for Number {
     fn div(self, rhs: Self) -> Self::Output {
         match (self, rhs) {
             (Number::NaturalNumber(v1), Number::NaturalNumber(v2)) => {
-                Number::DecimalNumber(BigRational::new(v1, v2))
+                Number::decimal(BigRational::new(v1, v2))
             }
             (Number::NaturalNumber(v1), Number::DecimalNumber(v2)) => {
-                Number::DecimalNumber(BigRational::from(v1) / v2)
+                Number::decimal(BigRational::from(v1) / v2)
             }
             (Number::DecimalNumber(v1), Number::NaturalNumber(v2)) => {
-                Number::DecimalNumber(v1 / BigRational::from(v2))
+                Number::decimal(v1 / BigRational::from(v2))
             }
-            (Number::DecimalNumber(v1), Number::DecimalNumber(v2)) => {
-                Number::DecimalNumber(v1 / v2)
-            }
+            (Number::DecimalNumber(v1), Number::DecimalNumber(v2)) => Number::decimal(v1 / v2),
         }
     }
 }
@@ -802,5 +850,61 @@ mod tests {
             (f64::try_from(Number::NaturalNumber(BigInt::from(10))).unwrap() - 10.0).abs()
                 < f64::EPSILON
         );
+    }
+
+    #[test]
+    fn test_decimal_constructor_degrades_integral_rationals() {
+        // 4/2 reduces to 2, which is an integer: it must not stay tagged as decimal.
+        let n = Number::decimal(BigRational::new(BigInt::from(4), BigInt::from(2)));
+        assert_eq!(n, Number::NaturalNumber(BigInt::from(2)));
+        assert!(matches!(n, Number::NaturalNumber(_)));
+
+        // 1/2 is not integral and must stay decimal.
+        let half = Number::decimal(BigRational::new(BigInt::from(1), BigInt::from(2)));
+        assert!(matches!(half, Number::DecimalNumber(_)));
+    }
+
+    #[test]
+    fn test_as_integer_reads_the_value_not_the_tag() {
+        assert_eq!(
+            Number::NaturalNumber(BigInt::from(7)).as_integer(),
+            Some(BigInt::from(7))
+        );
+        // Built by hand, bypassing the constructor: the value is still integral.
+        assert_eq!(
+            Number::DecimalNumber(BigRational::from_integer(BigInt::from(7))).as_integer(),
+            Some(BigInt::from(7))
+        );
+        assert_eq!(
+            Number::DecimalNumber(BigRational::new(BigInt::from(3), BigInt::from(2))).as_integer(),
+            None
+        );
+    }
+
+    #[test]
+    fn test_eq_agrees_with_partial_cmp_across_variants() {
+        use std::cmp::Ordering;
+        let pairs = [
+            (
+                Number::NaturalNumber(BigInt::from(2)),
+                Number::DecimalNumber(BigRational::from_integer(BigInt::from(2))),
+            ),
+            (
+                Number::NaturalNumber(BigInt::from(-3)),
+                Number::DecimalNumber(BigRational::new(BigInt::from(-6), BigInt::from(2))),
+            ),
+            (
+                Number::NaturalNumber(BigInt::from(2)),
+                Number::DecimalNumber(BigRational::new(BigInt::from(5), BigInt::from(2))),
+            ),
+        ];
+        for (a, b) in pairs {
+            let equal_by_eq = a == b;
+            let equal_by_ord = a.partial_cmp(&b) == Some(Ordering::Equal);
+            assert_eq!(
+                equal_by_eq, equal_by_ord,
+                "PartialEq and PartialOrd disagree on {a} vs {b}"
+            );
+        }
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -9,6 +9,18 @@ use std::{
 /// Enum Type [Number]. Either an BigInt integer [`Number::NaturalNumber`]
 /// or a [`BigRational`] rational number [`Number::DecimalNumber`]
 ///
+/// # Invariant
+///
+/// A [`Number::DecimalNumber`] never holds a denominator of 1. A value that is
+/// mathematically a whole number is always a [`Number::NaturalNumber`], so every
+/// mathematical value has exactly one representation and the two variants never
+/// describe the same number.
+///
+/// [`Number::decimal`] is the constructor that maintains this, degrading an
+/// integral rational to [`Number::NaturalNumber`]; everything inside the crate
+/// builds decimals through it. Both variants are nevertheless publicly
+/// constructible, so code that builds a [`Number::DecimalNumber`] directly is
+/// responsible for upholding the rule itself — prefer [`Number::decimal`].
 #[derive(Debug, Clone)]
 pub enum Number {
     /// an Integer [BigInt]

--- a/src/token.rs
+++ b/src/token.rs
@@ -138,14 +138,34 @@ pub enum MathFunction {
 impl MathFunction {
     /// How many arguments this function takes.
     ///
-    /// [`MathFunction::None`] is unreachable — [`Token::get_some`] never yields
-    /// it — and reports 1 rather than panicking, so that no input can reach a
-    /// panic through this path.
+    /// [`MathFunction::None`] is unreachable — nothing in the tokenizer ever
+    /// produces it — and reports 1 rather than panicking, so that no input can
+    /// reach a panic through this path.
+    ///
+    /// The match is written out variant by variant, rather than falling back
+    /// on a wildcard arm, so that adding a new function forces its author to
+    /// state its arity here instead of silently inheriting 1.
     #[must_use]
     pub const fn arity(self) -> u8 {
         match self {
             MathFunction::Max | MathFunction::Min => 2,
-            _ => 1,
+            MathFunction::Sin
+            | MathFunction::Cos
+            | MathFunction::Tan
+            | MathFunction::ASin
+            | MathFunction::ACos
+            | MathFunction::ATan
+            | MathFunction::Ln
+            | MathFunction::Log
+            | MathFunction::Abs
+            | MathFunction::Sqrt
+            | MathFunction::Floor
+            | MathFunction::Ceil
+            | MathFunction::Round
+            | MathFunction::Exp
+            | MathFunction::Pdf
+            | MathFunction::Cdf
+            | MathFunction::None => 1,
         }
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -135,6 +135,21 @@ pub enum MathFunction {
     None,
 }
 
+impl MathFunction {
+    /// How many arguments this function takes.
+    ///
+    /// [`MathFunction::None`] is unreachable — [`Token::get_some`] never yields
+    /// it — and reports 1 rather than panicking, so that no input can reach a
+    /// panic through this path.
+    #[must_use]
+    pub const fn arity(self) -> u8 {
+        match self {
+            MathFunction::Max | MathFunction::Min => 2,
+            _ => 1,
+        }
+    }
+}
+
 impl Token<'_> {
     /// Converts a char to a [`Token::Operator`]
     /// or just returns [`None`] if nothing matches.
@@ -906,5 +921,13 @@ mod tests {
                 "PartialEq and PartialOrd disagree on {a} vs {b}"
             );
         }
+    }
+
+    #[test]
+    fn test_arity_of_the_two_argument_functions() {
+        assert_eq!(MathFunction::Max.arity(), 2);
+        assert_eq!(MathFunction::Min.arity(), 2);
+        assert_eq!(MathFunction::Sin.arity(), 1);
+        assert_eq!(MathFunction::Cdf.arity(), 1);
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -613,7 +613,10 @@ fn test_comma_outside_a_function_call_is_diagnosed() {
 #[test]
 fn test_a_function_name_requires_parentheses() {
     let session = Session::init();
-    for expr in ["sin 5", "sqrt 16", "cos"] {
+    // "sin;" pins down that a pending function cannot survive a ';' statement
+    // boundary either: the mandatory-parenthesis check fires on the very next
+    // token, whatever it is, before the ';' arm ever runs.
+    for expr in ["sin 5", "sqrt 16", "cos", "sin;"] {
         let mut resolver = session.process(expr);
         let err = resolver.resolve().unwrap_err().to_string();
         assert!(
@@ -630,4 +633,71 @@ fn test_nested_and_multi_argument_calls_still_work() {
     resolve_natural!("min(max(2,3),max(5,1))", 3);
     resolve_natural!("max(1+2,3*4)-min(10,5)", 7);
     resolve_natural!("max(1,(2+3))", 5);
+}
+
+#[test]
+fn test_unclosed_bracket_before_semicolon_is_diagnosed() {
+    // Before the fix, the open bracket's frame survived the ';' unclosed, and
+    // the mismatch surfaced later as a misleading arity error instead of
+    // naming the real problem.
+    let session = Session::init();
+    let mut resolver = session.process("max(1; 2)");
+    let err = resolver.resolve().unwrap_err().to_string();
+    assert!(err.contains("before ';'"), "message was: {err}");
+    assert!(
+        !err.contains("expects"),
+        "should not be reported as an arity mismatch: {err}"
+    );
+}
+
+#[test]
+fn test_empty_argument_slot_is_diagnosed() {
+    // A comma with nothing before or after it must be its own diagnosis, not
+    // silently absorbed into the argument count.
+    let session = Session::init();
+    for expr in ["max(,1)", "max(1,)"] {
+        let mut resolver = session.process(expr);
+        let err = resolver.resolve().unwrap_err().to_string();
+        assert!(err.contains("empty"), "{expr} reported: {err}");
+    }
+}
+
+#[test]
+fn test_nested_empty_group_does_not_fake_an_argument() {
+    // The inner "()" is empty and must not be counted as content for the
+    // outer call's only argument slot.
+    let session = Session::init();
+    let mut resolver = session.process("sin(())");
+    let err = resolver.resolve().unwrap_err().to_string();
+    assert!(
+        err.contains("expects 1") && err.contains("0 given"),
+        "message was: {err}"
+    );
+}
+
+#[test]
+fn test_unbalanced_closing_bracket_is_diagnosed() {
+    let session = Session::init();
+    let mut resolver = session.process("1+2)");
+    let err = resolver.resolve().unwrap_err().to_string();
+    assert!(err.contains("Unbalanced brackets"), "message was: {err}");
+}
+
+#[test]
+fn test_single_argument_function_called_empty_is_diagnosed() {
+    let session = Session::init();
+    let mut resolver = session.process("sin()");
+    let err = resolver.resolve().unwrap_err().to_string();
+    assert!(
+        err.contains("expects 1") && err.contains("0 given"),
+        "message was: {err}"
+    );
+}
+
+#[test]
+fn test_comma_inside_nested_plain_group_within_a_call_is_diagnosed() {
+    let session = Session::init();
+    let mut resolver = session.process("max((1,2),3)");
+    let err = resolver.resolve().unwrap_err().to_string();
+    assert!(err.contains("function call"), "message was: {err}");
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -554,3 +554,29 @@ fn test_growth_through_multiplication_is_caught() {
     let mut resolver = session.process("x=2^2000; x*x");
     assert!(resolver.resolve().is_err(), "the product needs 4001 bits");
 }
+
+#[test]
+fn test_oversized_exponent_reports_its_own_message() {
+    // The exponent itself doesn't fit in a u64 (it's far larger than u64::MAX),
+    // so this must be refused before any size prediction is even attempted - and
+    // with its own message, not the unrelated "Invalid power operation" that
+    // covers a different failure (a non-integer powf conversion).
+    let session = Session::init();
+    let mut resolver = session.process("2^99999999999999999999");
+    let err = resolver.resolve().unwrap_err().to_string();
+    assert!(err.contains("exponent is too large"), "message was: {err}");
+    assert!(
+        !err.contains("Invalid power operation"),
+        "message was: {err}"
+    );
+}
+
+#[test]
+fn test_degenerate_power_bases_are_not_refused() {
+    // 1^n, 0^n and (-1)^n all stay tiny no matter how large n is, and are cheap to
+    // compute (repeated squaring on a magnitude-1 base never grows). A size
+    // prediction that multiplies base bits by the exponent must not refuse these.
+    resolve_natural!("1^10000000", 1);
+    resolve_natural!("0^10000000", 0);
+    resolve_natural!("(-1)^10000000", 1); // even exponent
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,4 +1,5 @@
 use num::BigInt;
+use yarer::limits::Limits;
 use yarer::rpn_resolver::*;
 use yarer::session::Session;
 use yarer::token::*;
@@ -497,4 +498,55 @@ fn test_non_integral_results_stay_decimal() {
             "{expr} produced {result:?}, expected a DecimalNumber"
         );
     }
+}
+
+#[test]
+fn test_oversized_factorial_is_refused_not_computed() {
+    // Before the limit this did not return at all. The test is its own alarm:
+    // if the guard stops working, the suite hangs here instead of failing.
+    let session = Session::init();
+    let mut resolver = session.process("999999999!");
+    let err = resolver.resolve().unwrap_err().to_string();
+    assert!(err.contains("size limit"), "message was: {err}");
+}
+
+#[test]
+fn test_oversized_power_is_refused_not_computed() {
+    let session = Session::init();
+    let mut resolver = session.process("10^100000000");
+    let err = resolver.resolve().unwrap_err().to_string();
+    assert!(err.contains("size limit"), "message was: {err}");
+}
+
+#[test]
+fn test_legitimate_big_values_still_pass_the_default_limit() {
+    resolve_natural!("2^64", 18_446_744_073_709_551_616_i128);
+    let session = Session::init();
+    let mut resolver = session.process("1000!");
+    // 1000! needs about 8530 bits, comfortably inside the default budget.
+    assert!(resolver.resolve().is_ok());
+}
+
+#[test]
+fn test_the_limit_is_configurable() {
+    let session = Session::with_limits(Limits { max_value_bits: 64 });
+    let mut resolver = session.process("2^100");
+    assert!(
+        resolver.resolve().is_err(),
+        "2^100 needs 101 bits, over a 64-bit budget"
+    );
+
+    let mut small = session.process("2^10");
+    assert!(small.resolve().is_ok());
+}
+
+#[test]
+fn test_growth_through_multiplication_is_caught() {
+    // 2^3000 occupies 3001 bits and is admitted; squaring it needs 6001, which
+    // is not. Each step is individually under budget only until it is not.
+    let session = Session::with_limits(Limits {
+        max_value_bits: 4096,
+    });
+    let mut resolver = session.process("x=2^3000; x*x");
+    assert!(resolver.resolve().is_err(), "the product needs 6001 bits");
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -14,13 +14,18 @@ macro_rules! resolve {
     };
 }
 
+/// Asserts the numeric value of an expression, within 1e-10.
+///
+/// It deliberately does not assert which `Number` variant came back: under the
+/// canonicalisation invariant an integral result is a `NaturalNumber`, and
+/// which side of that line an expression falls on is asserted once, on purpose,
+/// by `test_integral_results_are_natural_numbers`.
 macro_rules! resolve_decimal {
     ($expr:expr, $expected:expr) => {{
         let session = Session::init();
         let mut resolver = session.process($expr);
         let result = resolver.resolve().unwrap();
-        assert!(matches!(result, Number::DecimalNumber(_)));
-        let res_f: f64 = result.clone().try_into().unwrap();
+        let res_f: f64 = result.try_into().unwrap();
         assert!((res_f - $expected).abs() < 1e-10);
     }};
     () => {
@@ -454,4 +459,42 @@ fn test_setf_declares_a_decimal_variable() {
     let mut resolver = session.process("r*2");
     let v: f64 = resolver.resolve().unwrap().try_into().unwrap();
     assert!((v - 5.0).abs() < 1e-10);
+}
+
+#[test]
+fn test_factorial_accepts_integral_results_of_functions() {
+    // These all produced "Factorial is only defined for non-negative integers"
+    // before the Number invariant, because the functions tagged an integral
+    // result as decimal and the factorial branched on the tag.
+    resolve_natural!("abs(-3)!", 6);
+    resolve_natural!("floor(2.5)!", 2);
+    resolve_natural!("max(3,2)!", 6);
+    resolve_natural!("round(2.4)!", 2);
+    resolve_natural!("(6/3)!", 2);
+}
+
+#[test]
+fn test_integral_results_are_natural_numbers() {
+    let session = Session::init();
+    for expr in ["6/3", "floor(3.7)", "exp(0)", "max(1,2)", "sqrt(16)"] {
+        let mut resolver = session.process(expr);
+        let result = resolver.resolve().unwrap();
+        assert!(
+            matches!(result, Number::NaturalNumber(_)),
+            "{expr} produced {result:?}, expected a NaturalNumber"
+        );
+    }
+}
+
+#[test]
+fn test_non_integral_results_stay_decimal() {
+    let session = Session::init();
+    for expr in ["1/3", "abs(-2.5)", "2^-3", "sqrt(2)"] {
+        let mut resolver = session.process(expr);
+        let result = resolver.resolve().unwrap();
+        assert!(
+            matches!(result, Number::DecimalNumber(_)),
+            "{expr} produced {result:?}, expected a DecimalNumber"
+        );
+    }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -622,6 +622,39 @@ fn test_an_oversized_literal_is_refused() {
 }
 
 #[test]
+fn test_an_oversized_variable_is_refused() {
+    // Same hole as the literal, one match arm over. Bounding untrusted input is
+    // the whole reason to call with_limits, and setf is a way in that does not
+    // pass through any of the checked operators: 1e308 is stored as a ~1024-bit
+    // integer, and reading it back needs no arithmetic at all.
+    let session = Session::with_limits(Limits { max_value_bits: 64 });
+    session.setf("x", 1e308);
+
+    // Bare "x" is the case no other guard can catch: the value is pushed and
+    // returned without a single operator running over it.
+    let mut resolver = session.process("x");
+    let err = resolver.resolve().unwrap_err().to_string();
+    assert!(err.contains("occupies"), "message was: {err}");
+    assert!(err.contains("size limit"), "message was: {err}");
+
+    // A variable inside the budget still reads back normally.
+    session.set("y", 7);
+    let mut inside = session.process("y*2");
+    assert_eq!(
+        inside.resolve().unwrap(),
+        Number::NaturalNumber(BigInt::from(14))
+    );
+
+    // An undefined variable still resolves to zero. That is deliberate, and a
+    // size check on the variable push must not turn it into an error.
+    let mut undefined = session.process("z+1");
+    assert_eq!(
+        undefined.resolve().unwrap(),
+        Number::NaturalNumber(BigInt::from(1))
+    );
+}
+
+#[test]
 fn test_wrong_arity_is_diagnosed_by_name() {
     let session = Session::init();
     for (expr, expected, given) in [("max(1)", 2, 1), ("max(1,2,3)", 2, 3), ("sin(1,2)", 1, 2)] {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -580,3 +580,54 @@ fn test_degenerate_power_bases_are_not_refused() {
     resolve_natural!("0^10000000", 0);
     resolve_natural!("(-1)^10000000", 1); // even exponent
 }
+
+#[test]
+fn test_wrong_arity_is_diagnosed_by_name() {
+    let session = Session::init();
+    for (expr, expected, given) in [("max(1)", 2, 1), ("max(1,2,3)", 2, 3), ("sin(1,2)", 1, 2)] {
+        let mut resolver = session.process(expr);
+        let err = resolver.resolve().unwrap_err().to_string();
+        assert!(
+            err.contains(&format!("expects {expected}")) && err.contains(&format!("{given} given")),
+            "{expr} reported: {err}"
+        );
+    }
+}
+
+#[test]
+fn test_empty_argument_list_is_diagnosed() {
+    let session = Session::init();
+    let mut resolver = session.process("max()");
+    let err = resolver.resolve().unwrap_err().to_string();
+    assert!(err.contains("0 given"), "message was: {err}");
+}
+
+#[test]
+fn test_comma_outside_a_function_call_is_diagnosed() {
+    let session = Session::init();
+    let mut resolver = session.process("(1,2)");
+    let err = resolver.resolve().unwrap_err().to_string();
+    assert!(err.contains("function call"), "message was: {err}");
+}
+
+#[test]
+fn test_a_function_name_requires_parentheses() {
+    let session = Session::init();
+    for expr in ["sin 5", "sqrt 16", "cos"] {
+        let mut resolver = session.process(expr);
+        let err = resolver.resolve().unwrap_err().to_string();
+        assert!(
+            err.contains("must be followed by"),
+            "{expr} reported: {err}"
+        );
+    }
+    // The parenthesised form is untouched.
+    resolve_decimal!("sin(5)", -0.9589242746631385);
+}
+
+#[test]
+fn test_nested_and_multi_argument_calls_still_work() {
+    resolve_natural!("min(max(2,3),max(5,1))", 3);
+    resolve_natural!("max(1+2,3*4)-min(10,5)", 7);
+    resolve_natural!("max(1,(2+3))", 5);
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -542,11 +542,15 @@ fn test_the_limit_is_configurable() {
 
 #[test]
 fn test_growth_through_multiplication_is_caught() {
-    // 2^3000 occupies 3001 bits and is admitted; squaring it needs 6001, which
-    // is not. Each step is individually under budget only until it is not.
+    // Budget 4000 is exactly the power's own prediction for this base and
+    // exponent (size_in_bits(2) * 2000 = 2 * 2000 = 4000): the largest value the
+    // predictive power check admits for "2^2000", so a failure here can only come
+    // from the multiplication, not from the power check firing again. 2^2000 is
+    // actually 2001 bits (passes both checks); squaring it needs 4001 bits, over
+    // budget, and only the post-hoc Mul check can catch that.
     let session = Session::with_limits(Limits {
-        max_value_bits: 4096,
+        max_value_bits: 4000,
     });
-    let mut resolver = session.process("x=2^3000; x*x");
-    assert!(resolver.resolve().is_err(), "the product needs 6001 bits");
+    let mut resolver = session.process("x=2^2000; x*x");
+    assert!(resolver.resolve().is_err(), "the product needs 4001 bits");
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -655,6 +655,43 @@ fn test_an_oversized_variable_is_refused() {
 }
 
 #[test]
+fn test_a_tiny_budget_rejects_the_builtin_constants() {
+    // The constants are f64s held exactly as rationals, so they are wide:
+    // numerator bits plus denominator bits, tau is the narrowest at 98 and gamma
+    // the widest at 107 (pi is 884279719003555/281474976710656, 50 + 49 = 99).
+    // A variable is size-checked as it is pushed, so a small budget rejects a
+    // value the caller never supplied. This test exists so the 107-bit floor
+    // quoted by Session::with_limits stays a measured number, not folklore.
+    let below_all = Session::with_limits(Limits { max_value_bits: 97 });
+    for name in ["pi", "e", "tau", "phi", "gamma"] {
+        let mut resolver = below_all.process(name);
+        let err = resolver.resolve().unwrap_err().to_string();
+        assert!(err.contains("size limit"), "{name} reported: {err}");
+    }
+
+    // 107 is the exact floor, pinned from both sides: one bit under it the
+    // widest constant still does not fit, at it every constant does. Asserting
+    // only the lower bound would pass for any number that happens to be too
+    // small, which is how a figure like this drifts out of date unnoticed.
+    let one_short = Session::with_limits(Limits {
+        max_value_bits: 106,
+    });
+    let mut widest = one_short.process("gamma");
+    assert!(widest.resolve().is_err(), "gamma fits in 106 bits?");
+
+    let exact = Session::with_limits(Limits {
+        max_value_bits: 107,
+    });
+    for name in ["pi", "e", "tau", "phi", "gamma"] {
+        let mut resolver = exact.process(name);
+        assert!(
+            resolver.resolve().is_ok(),
+            "{name} was rejected at 107 bits"
+        );
+    }
+}
+
+#[test]
 fn test_wrong_arity_is_diagnosed_by_name() {
     let session = Session::init();
     for (expr, expected, given) in [("max(1)", 2, 1), ("max(1,2,3)", 2, 3), ("sin(1,2)", 1, 2)] {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -208,9 +208,13 @@ fn test_session_set() {
     let session = Session::init();
     session.set("x", 4);
     let mut resolver: RpnResolver = session.process("x+2*3/(4-5)");
-    assert_eq!(
-        resolver.resolve().unwrap(),
-        Number::DecimalNumber(num_rational::BigRational::from_float(-2.0).unwrap())
+    let result = resolver.resolve().unwrap();
+    assert_eq!(result, Number::NaturalNumber(BigInt::from(-2)));
+    // Cross-variant equality would accept DecimalNumber(-2/1) above, so the
+    // variant has to be asserted separately for this to notice a regression.
+    assert!(
+        matches!(result, Number::NaturalNumber(_)),
+        "produced {result:?}, expected a NaturalNumber"
     );
 }
 
@@ -315,9 +319,14 @@ fn test_large_integer_division_and_negative_power_do_not_panic() {
     );
 
     let mut resolver = session.process("(10^100)^-1 * 10^100");
-    assert_eq!(
-        resolver.resolve().unwrap(),
-        Number::DecimalNumber(num_rational::BigRational::from_integer(BigInt::from(1)))
+    let result = resolver.resolve().unwrap();
+    assert_eq!(result, Number::NaturalNumber(BigInt::from(1)));
+    // A reciprocal multiplied back out lands exactly on 1, which is integral:
+    // the variant is the whole point here, and cross-variant equality would let
+    // DecimalNumber(1/1) through the assertion above.
+    assert!(
+        matches!(result, Number::NaturalNumber(_)),
+        "produced {result:?}, expected a NaturalNumber"
     );
 }
 
@@ -552,7 +561,11 @@ fn test_growth_through_multiplication_is_caught() {
         max_value_bits: 4000,
     });
     let mut resolver = session.process("x=2^2000; x*x");
-    assert!(resolver.resolve().is_err(), "the product needs 4001 bits");
+    let err = resolver.resolve().unwrap_err().to_string();
+    // "occupies" is the post-hoc wording; a prediction says "would need". Asserting
+    // the wording is what makes the paragraph above a claim the test checks rather
+    // than a comment asking to be believed.
+    assert!(err.contains("occupies"), "message was: {err}");
 }
 
 #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -683,20 +683,34 @@ fn test_a_materialised_power_is_measured_not_just_predicted() {
 }
 
 #[test]
-fn test_a_materialised_factorial_is_measured_not_just_predicted() {
-    // predicted_factorial_bits is a three-term Stirling series rounded up. Over
-    // n = 1..=60000 it over-estimates everywhere except n = 2, where it predicts
-    // 1 bit and 2! actually needs 2 -- the one case its own doc calls out.
-    //
-    // Reaching it takes some doing, which is the interesting part: under a 1-bit
-    // budget every checked route to the value 2 is refused, because 2 is a 2-bit
-    // operand. floor(exp(1)) gets there anyway, since a function result is not
-    // size-checked. So the predictive guard admits the factorial and, without a
-    // post-hoc check, a 2-bit value is returned under a 1-bit budget.
+fn test_a_function_result_is_measured_like_any_other_value() {
+    // A function result is bounded by construction, since every built-in routes
+    // its argument through f64 -- but bounded is not measured, and the gap is not
+    // academic. While this arm was unchecked it was the one way to get a value
+    // onto the stack that nothing had measured, and the guards downstream assume
+    // their inputs were measured. floor(exp(1))! returned 2 under a 1-bit budget
+    // for exactly that reason: the factorial's predictive guard is a bit short at
+    // n = 2, and 2 is a 2-bit operand that no checked arm would have admitted.
     let one_bit = Session::with_limits(Limits { max_value_bits: 1 });
-    let mut smuggled = one_bit.process("floor(exp(1))!");
-    let err = smuggled.resolve().unwrap_err().to_string();
-    assert!(err.contains("occupies"), "message was: {err}");
+    for expr in ["exp(1)", "floor(exp(1))", "floor(exp(1))!"] {
+        let mut resolver = one_bit.process(expr);
+        let err = resolver.resolve().unwrap_err().to_string();
+        assert!(err.contains("occupies"), "{expr} reported: {err}");
+    }
+
+    // Nothing legitimate is refused by this: a function result is f64-bounded, so
+    // it is far below any budget anyone would set on purpose.
+    resolve_natural!("1/cos(0)", 1);
+    resolve_decimal!("sin(1)", 0.841_470_984_807_896_5);
+    resolve_decimal!("9801/(2206*sqrt(2))", 3.141_592_730_013_305_5);
+
+    // NOTE for whoever reads this next: closing this arm makes the factorial's
+    // own post-hoc check unreachable, since every route to an operand now
+    // measures it first. That check stays anyway -- n = 2 is the only value up to
+    // 60000 where the prediction falls short, which is an empirical bound and not
+    // a proof -- but it is now shadowed, and a test claiming to exercise it would
+    // really be exercising this arm. That is why this test asserts the function
+    // arm and says so, rather than keeping the old factorial framing green.
 
     // The predictive refusal must survive: 999999999! has to stay a fast "no",
     // not become a computation that is measured afterwards.

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -579,6 +579,33 @@ fn test_degenerate_power_bases_are_not_refused() {
     resolve_natural!("1^10000000", 1);
     resolve_natural!("0^10000000", 0);
     resolve_natural!("(-1)^10000000", 1); // even exponent
+
+    // The same argument holds for an exponent too large to fit in a u64. Testing
+    // the base's magnitude only *after* that conversion refused this one with
+    // "the exponent is too large to evaluate under any size limit", which is
+    // factually wrong for a base of magnitude 1: 1^n is 1 under every limit.
+    resolve_natural!("1^99999999999999999999", 1);
+    resolve_natural!("0^99999999999999999999", 0);
+}
+
+#[test]
+fn test_an_oversized_literal_is_refused() {
+    // max_value_bits is documented as bounding the size of any intermediate or
+    // final result. A literal pushed straight onto the stack is one of those, so
+    // the budget has to apply to it as well, whatever produced it.
+    let session = Session::with_limits(Limits { max_value_bits: 32 });
+    let mut resolver = session.process("99999999999999999999");
+    let err = resolver.resolve().unwrap_err().to_string();
+    assert!(err.contains("occupies"), "message was: {err}");
+    assert!(err.contains("size limit"), "message was: {err}");
+
+    // A literal inside the budget is untouched, so the guard is not simply
+    // refusing everything.
+    let mut inside = session.process("123+1");
+    assert_eq!(
+        inside.resolve().unwrap(),
+        Number::NaturalNumber(BigInt::from(124))
+    );
 }
 
 #[test]
@@ -681,6 +708,24 @@ fn test_unbalanced_closing_bracket_is_diagnosed() {
     let mut resolver = session.process("1+2)");
     let err = resolver.resolve().unwrap_err().to_string();
     assert!(err.contains("Unbalanced brackets"), "message was: {err}");
+}
+
+#[test]
+fn test_unbalanced_opening_bracket_is_diagnosed() {
+    // The same condition class as the test above, and it used to get the generic
+    // "malformed expression" message instead of the named one. "max(1,2" is the
+    // sharper case: the bracket never closes, so the arity check on the closing
+    // bracket never ran at all.
+    let session = Session::init();
+    for expr in ["(1+2", "max(1,2"] {
+        let mut resolver = session.process(expr);
+        let err = resolver.resolve().unwrap_err().to_string();
+        assert!(
+            err.contains("Unbalanced brackets"),
+            "{expr} reported: {err}"
+        );
+        assert!(!err.contains("malformed"), "{expr} reported: {err}");
+    }
 }
 
 #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -655,6 +655,58 @@ fn test_an_oversized_variable_is_refused() {
 }
 
 #[test]
+fn test_a_materialised_power_is_measured_not_just_predicted() {
+    // The size prediction is a pre-filter, not the guarantee, and there are two
+    // ways past it. Neither of these is caught by any predictive check.
+
+    // 1. The powf path never consults the prediction at all: "2^0.5" is a
+    //    non-integer exponent, so it converts to f64 and comes back as a
+    //    rational of roughly 53 + 53 bits.
+    let tight = Session::with_limits(Limits { max_value_bits: 16 });
+    let mut irrational = tight.process("2^0.5");
+    let err = irrational.resolve().unwrap_err().to_string();
+    assert!(err.contains("occupies"), "message was: {err}");
+
+    // 2. A negative exponent is predicted on the magnitude of base^|exponent|,
+    //    but the value returned is the reciprocal, whose denominator counts too.
+    //    "2^-1" predicts 2 bits and yields 1/2, which measures 1 + 2 = 3.
+    let two_bits = Session::with_limits(Limits { max_value_bits: 2 });
+    let mut reciprocal = two_bits.process("2^-1");
+    let err = reciprocal.resolve().unwrap_err().to_string();
+    assert!(err.contains("occupies"), "message was: {err}");
+
+    // Three bits is exactly enough, which pins the boundary rather than just
+    // asserting that something was refused.
+    let three_bits = Session::with_limits(Limits { max_value_bits: 3 });
+    let mut fits = three_bits.process("2^-1");
+    assert_eq!(fits.resolve().unwrap().to_string(), "0.5");
+}
+
+#[test]
+fn test_a_materialised_factorial_is_measured_not_just_predicted() {
+    // predicted_factorial_bits is a three-term Stirling series rounded up. Over
+    // n = 1..=60000 it over-estimates everywhere except n = 2, where it predicts
+    // 1 bit and 2! actually needs 2 -- the one case its own doc calls out.
+    //
+    // Reaching it takes some doing, which is the interesting part: under a 1-bit
+    // budget every checked route to the value 2 is refused, because 2 is a 2-bit
+    // operand. floor(exp(1)) gets there anyway, since a function result is not
+    // size-checked. So the predictive guard admits the factorial and, without a
+    // post-hoc check, a 2-bit value is returned under a 1-bit budget.
+    let one_bit = Session::with_limits(Limits { max_value_bits: 1 });
+    let mut smuggled = one_bit.process("floor(exp(1))!");
+    let err = smuggled.resolve().unwrap_err().to_string();
+    assert!(err.contains("occupies"), "message was: {err}");
+
+    // The predictive refusal must survive: 999999999! has to stay a fast "no",
+    // not become a computation that is measured afterwards.
+    let default = Session::init();
+    let mut huge = default.process("999999999!");
+    let err = huge.resolve().unwrap_err().to_string();
+    assert!(err.contains("would need"), "message was: {err}");
+}
+
+#[test]
 fn test_a_tiny_budget_rejects_the_builtin_constants() {
     // The constants are f64s held exactly as rationals, so they are wide:
     // numerator bits plus denominator bits, tau is the narrowest at 98 and gamma


### PR DESCRIPTION
Stage 1 of making yarer production-ready: a core an embedder can rely on. No new features — four verified reliability defects fixed, plus the documentation and tests that make the new behaviour honest.

Breaking changes are declared and intentional; the target is 0.3.0. The version in `Cargo.toml` is deliberately left at 0.2.0 — Stage 2 (typed errors, source positions, `Send`/`Sync`) will add more breaking changes, so the bump belongs with the release, not here.

## What was wrong

Four defects, each reproduced against the built binary before being fixed:

- **`1/0.0` panicked.** The derived `PartialEq` compared `Number` by enum tag, so the divide-by-zero guard never matched `DecimalNumber(0/1)` and `BigRational::new(v, 0)` panicked. The same derive made `PartialEq` and `PartialOrd` disagree, which violates their contract.
- **`999999999!` and `10^100000000` never returned.** They ran until memory was exhausted.
- **Wrong argument counts failed late and anonymously.** `max(1)`, `sin(1,2)` and `sin 5` all produced `Runtime Error: The mathematical expression is malformed.`, from the evaluation stack, where the function's name no longer exists.
- **The same value had two representations.** `2.0`, `4/2` and `max(1,2)` could each come back as `NaturalNumber(2)` or `DecimalNumber(2/1)` depending on the route taken.

## What changed

**Every value has exactly one representation.** `Number::decimal` is now the only constructor for a decimal, and it degrades an integral rational to `NaturalNumber`. `PartialEq` is hand-written and value-based, consistent with `PartialOrd`. The `1/0.0` panic closes as a side effect: the guard now sees the zero it was always meant to see.

**Oversized results are refused instead of computed.** New `Limits { max_value_bits }`, 1 Mibit by default — about 315,000 decimal digits — configurable per session through `Session::with_limits`. Arithmetic is checked after the fact; powers and factorials are checked *before* any work happens, using a size prediction rather than a measurement:

- factorials via Stirling, `log2(n!) ≈ n·log2(n) − n·log2(e) + 0.5·log2(2πn)`, which matches `lgamma(n+1)/ln(2)` to 0.00 bits at the boundary;
- powers via `bits(base) × |exponent|`, a provable upper bound, which is why powers need no post-hoc check.

`999999999!` and `10^100000000` now return a diagnostic in milliseconds. The largest factorial admitted at the default budget is `71421!`, about 0.43 s in release.

**Argument counts are validated while the RPN form is built,** where the function's name and the bracket structure still exist. A per-bracket frame stack tracks the owning function, the separator count and whether each argument slot has content:

| input | before | after |
|---|---|---|
| `max(1,2,3)` | `The mathematical expression is malformed.` | `Function 'max' expects 2 argument(s), 3 given.` |
| `sin 5` | silently evaluated as `sin(5)` | `Function 'sin' must be followed by '('.` |
| `max(,1)` | `The mathematical expression is malformed.` | `A function argument cannot be empty.` |
| `(1,2)` | `The mathematical expression is malformed.` | `',' is only valid between the arguments of a function call.` |
| `(1+2` | `The mathematical expression is malformed.` | `Unbalanced brackets.` |
| `max(1; 2)` | a misleading arity error | `A bracket must be closed before ';'.` |

**Function evaluation moved to its own module** (`src/functions.rs`), which shrank `resolve()` from 243 lines to 141 and gave the following three changes somewhere coherent to land.

## Declared behaviour changes

Gathered verbatim in `docs/superpowers/specs/2026-08-04-reliable-core-design.md` so a release note can be written from them:

1. **Integral results are returned as `Number::NaturalNumber`.** `2.5+2.5` is `5`, `1/cos(0)` is `1`, `6/3` is `2`, and `setf("x", 4.0)` stores `4`. `DecimalNumber` appears only when the value genuinely has a fractional part. Code matching on the variant to decide rendering may need adjusting; code comparing or converting values is unaffected, since equality and ordering work across variants.
2. **Results exceeding the size budget are refused.** Bounded per session by `Limits::max_value_bits`, applying to every literal, every variable read and every arithmetic result.
3. **A function name must be followed by `(`.** `sin 5` and `sqrt 16` were previously accepted; they are now parse errors that name the function.

Undefined variables still evaluate to `0`, matching `bc`. Prefix `!5` is still accepted alongside postfix `5!`. The interactive REPL is unchanged.

## Documentation

`README.md` and the crate-level docs described the *old* return-type rule, using two examples that this branch turns into counterexamples. Both were rewritten. `setf`'s doc comment promised a `DecimalNumber` it can no longer produce. Four README examples did not compile (`E0277` formatting a `Result`, `E0308` passing a float to `set`, which takes `i64`) — verified by extracting the blocks into a throwaway test, then fixed.

## Verification

- 41 lib + 53 integration + 5 doc tests, green.
- `cargo fmt --check` clean; no new clippy lint category, measured per-lint against the merge-base with a cleared cache; `cargo doc --no-deps` at the same 5 warnings as before the branch.
- No new dependencies — `Cargo.toml` and `Cargo.lock` are untouched.
- Five tests that asserted `DecimalNumber` for now-integral values were made sensitive again. Changing the expected variant was not enough: cross-variant equality means `NaturalNumber(2) == DecimalNumber(2/1)`, so each site also asserts the enum tag. Verified by de-canonicalising the constructor and confirming each fails.

## Known gaps, deliberately left

- Errors remain `anyhow`; typed errors with source positions are Stage 2.
- Operator-sequence validation is Stage 2: `max(1,*2)` passes the arity check and fails at evaluation.
- `[` and `]` remain bracket aliases, so `sin[5]` evaluates although the error text says parentheses.
- The size budget does not cover function results. Unreachable in practice — every built-in routes its argument through `f64` — and documented as such on the field rather than left implicit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stage 1 makes the evaluation core reliable. It fixes panics and non-termination, enforces a size budget with both predictions and exact checks on every stack value (including function results), validates function arity with clear errors, canonicalizes numeric values, extracts function evaluation into `src/functions.rs`, and documents known tech debt in `docs/tech-debt.md`.

- **Bug Fixes**
  - Prevented divide-by-zero panic in `1/0.0`; `Number` equality is now value-based and consistent with ordering.
  - Refuse oversized results fast and correctly: predict `n!` via Stirling and `a^b` via bit bounds, then verify the materialized value against the budget. Every value pushed to the stack is measured — literals, variables, arithmetic, powers, factorials, and function results — closing holes like `2^0.5`, `2^-1`, and `floor(exp(1))!` under tiny budgets.
  - Validate function arity while building RPN with specific errors (e.g., wrong counts, stray commas, unbalanced brackets); `sin 5` now errors and must be `sin(5)`.

- **Migration**
  - Integral results return as `Number::NaturalNumber`; `Number::DecimalNumber` only when the value has a fractional part. Update code that matches on the variant.
  - A function name must be followed by `(` (e.g., `sin(5)`).
  - Results over `Limits::max_value_bits` are refused (default ~1 Mibit); enforcement now covers all values, including function results. Configure per session via `Session::with_limits`.

<sup>Written for commit f8ede7e858b0f2cf12aa6c5c7d881f31efa3c446. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davassi/yarer/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

